### PR TITLE
pnpm 11 knowledge ownership: skill sync + doctor guidance (v3.0.1)

### DIFF
--- a/.claude/skills/ts-builds/SKILL.md
+++ b/.claude/skills/ts-builds/SKILL.md
@@ -36,7 +36,7 @@ pnpm init
 pnpm add -D ts-builds tsdown
 
 # Initialize project
-npx ts-builds init      # Creates .npmrc with hoist patterns
+npx ts-builds init      # Creates pnpm-workspace.yaml with hoist patterns
 npx ts-builds config    # Creates ts-builds.config.json
 
 # Create source files
@@ -56,7 +56,7 @@ npx ts-builds validate
 pnpm add -D ts-builds tsdown
 
 # Initialize and configure
-npx ts-builds init      # Creates .npmrc with hoist patterns
+npx ts-builds init      # Creates pnpm-workspace.yaml with hoist patterns
 npx ts-builds config    # Creates ts-builds.config.json
 npx ts-builds cleanup   # Remove redundant dependencies
 
@@ -72,7 +72,7 @@ npx ts-builds validate
 
 ```bash
 npx ts-builds            # Default: runs init
-npx ts-builds init       # Create .npmrc with hoist patterns (run first)
+npx ts-builds init       # Create pnpm-workspace.yaml with hoist patterns (run first)
 npx ts-builds config     # Create ts-builds.config.json
 npx ts-builds config --force  # Overwrite existing config (or -f)
 npx ts-builds info       # Show bundled packages you don't need to install

--- a/.claude/skills/ts-builds/SKILL.md
+++ b/.claude/skills/ts-builds/SKILL.md
@@ -327,7 +327,7 @@ pnpm 11 enables supply-chain protection by default. Do not disable these globall
 ```yaml
 # pnpm-workspace.yaml
 allowBuilds:
-  esbuild: false        # correct default — binary ships via @esbuild/<platform> optional deps
+  esbuild: false # correct default — binary ships via @esbuild/<platform> optional deps
   some-native-pkg: true # approve a package that genuinely needs its build script
 ```
 

--- a/.claude/skills/ts-builds/SKILL.md
+++ b/.claude/skills/ts-builds/SKILL.md
@@ -306,6 +306,37 @@ Configuration highlights:
 - ESNext target
 - Declaration files only (tsdown handles transpilation)
 
+## pnpm 11 Defaults
+
+Projects using ts-builds are pinned to pnpm 11 via the `packageManager` field. Settings live in `pnpm-workspace.yaml`, NOT `.npmrc` (auth/registry only under pnpm 11) or the `package.json` `pnpm` field (no longer read by pnpm 11).
+
+**Settings relocated to `pnpm-workspace.yaml`:** `publicHoistPattern`, `overrides`, `peerDependencyRules`, `minimumReleaseAgeExclude`, `allowBuilds`.
+
+### Supply-chain protections (intentionally left ON)
+
+pnpm 11 enables supply-chain protection by default. Do not disable these globally — approve specific packages instead.
+
+- **`minimumReleaseAge`** (default: 1440, i.e. 1 day) — pnpm refuses dependency versions published less than 24h ago. CI installs from the committed `pnpm-lock.yaml`, so pinned versions are unaffected; this only bites a fresh `pnpm add` or a lockfile re-resolution of a just-published package. One-off override: `pnpm install --config.minimumReleaseAge=0`. When a dep's semver range has no aged-enough version (e.g. `@types/node@^24.13.1`), add a pinned `minimumReleaseAgeExclude` entry — do not downgrade.
+- **`strictDepBuilds: true`** — installs fail hard (`ERR_PNPM_IGNORED_BUILDS`) on un-approved dependency build scripts. pnpm 10 only warned; pnpm 11 errors.
+- **`blockExoticSubdeps: true`** — blocks exotic sub-dependency resolutions.
+
+### `allowBuilds` (replaces legacy build-allow family)
+
+`allowBuilds` (added in pnpm v10.26.0) replaces the entire legacy family: `onlyBuiltDependencies`, `onlyBuiltDependenciesFile`, `neverBuiltDependencies`, `ignoredBuiltDependencies`, and `ignoreDepScripts`. It is a map of package matcher → boolean in `pnpm-workspace.yaml`.
+
+```yaml
+# pnpm-workspace.yaml
+allowBuilds:
+  esbuild: false        # correct default — binary ships via @esbuild/<platform> optional deps
+  some-native-pkg: true # approve a package that genuinely needs its build script
+```
+
+Use `allowBuilds.<pkg>: true` to approve a package's build script; `false` to explicitly decline. `esbuild: false` is correct and is the ts-builds default — esbuild's build script is NOT needed because its binary ships via `@esbuild/<platform>` optional dependencies.
+
+### Doctor and migration
+
+`ts-builds doctor` reports pnpm 11 readiness: it flags `public-hoist-pattern[]` lines in `.npmrc` and a `package.json` `pnpm` field (both ignored by pnpm 11). `ts-builds doctor --fix` migrates them to `pnpm-workspace.yaml`, strips inert `.npmrc` lines, and prunes the `pnpm` field. Exotic keys (e.g. `packageExtensions`) and pre-existing target keys are reported for manual migration rather than altered.
+
 ## Common Workflows
 
 ### Creating a New Library

--- a/.claude/skills/ts-builds/SKILL.md
+++ b/.claude/skills/ts-builds/SKILL.md
@@ -337,6 +337,8 @@ Use `allowBuilds.<pkg>: true` to approve a package's build script; `false` to ex
 
 `ts-builds doctor` reports pnpm 11 readiness: it flags `public-hoist-pattern[]` lines in `.npmrc` and a `package.json` `pnpm` field (both ignored by pnpm 11). `ts-builds doctor --fix` migrates them to `pnpm-workspace.yaml`, strips inert `.npmrc` lines, and prunes the `pnpm` field. Exotic keys (e.g. `packageExtensions`) and pre-existing target keys are reported for manual migration rather than altered.
 
+For a complete step-by-step runbook covering the full 2.x → 3.0.0 / pnpm 10 → 11 upgrade — including the `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`, `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`, and `ERR_PNPM_IGNORED_BUILDS` gotchas with exact fixes — see **references/standardization.md § "Migrating 2.x → 3.0.0 (pnpm 10 → 11)"**.
+
 ## Common Workflows
 
 ### Creating a New Library
@@ -493,7 +495,7 @@ When applying these standards to an existing project:
 ### Reference Documents
 
 - **references/template-setup.md** - Complete guide for using the template
-- **references/standardization.md** - Detailed migration guide for existing projects
+- **references/standardization.md** - Detailed migration guide for existing projects; includes the **"Migrating 2.x → 3.0.0 (pnpm 10 → 11)"** runbook at the end of the file
 - **references/tooling-reference.md** - Configuration examples and patterns
 
 ### External Links

--- a/.claude/skills/ts-builds/SKILL.md
+++ b/.claude/skills/ts-builds/SKILL.md
@@ -337,7 +337,7 @@ Use `allowBuilds.<pkg>: true` to approve a package's build script; `false` to ex
 
 `ts-builds doctor` reports pnpm 11 readiness: it flags `public-hoist-pattern[]` lines in `.npmrc` and a `package.json` `pnpm` field (both ignored by pnpm 11). `ts-builds doctor --fix` migrates them to `pnpm-workspace.yaml`, strips inert `.npmrc` lines, and prunes the `pnpm` field. Exotic keys (e.g. `packageExtensions`) and pre-existing target keys are reported for manual migration rather than altered.
 
-For a complete step-by-step runbook covering the full 2.x → 3.0.0 / pnpm 10 → 11 upgrade — including the `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`, `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`, and `ERR_PNPM_IGNORED_BUILDS` gotchas with exact fixes — see **references/standardization.md § "Migrating 2.x → 3.0.0 (pnpm 10 → 11)"**.
+For a complete step-by-step runbook covering the full 2.x → 3.0.0 / pnpm 10 → 11 upgrade — including the `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`, `ERR_PNPM_NO_MATURE_MATCHING_VERSION`, and `ERR_PNPM_IGNORED_BUILDS` gotchas with exact fixes — see **references/standardization.md § "Migrating 2.x → 3.0.0 (pnpm 10 → 11)"**.
 
 ## Common Workflows
 

--- a/.claude/skills/ts-builds/references/standardization.md
+++ b/.claude/skills/ts-builds/references/standardization.md
@@ -760,3 +760,114 @@ After successful migration:
 - **tsdown Documentation**: https://tsdown.egoist.dev/
 - **Vitest Migration**: https://vitest.dev/guide/migration.html
 - **ESLint Flat Config**: https://eslint.org/docs/latest/use/configure/configuration-files
+
+## Migrating 2.x → 3.0.0 (pnpm 10 → 11)
+
+Runbook for upgrading a consumer project from ts-builds 2.x + pnpm 10 to ts-builds 3.x + pnpm 11. Each step lists the command and the specific error or condition it resolves. Work through them in order.
+
+### Step 1: Bump ts-builds
+
+In the consumer project's `package.json`, update the devDependency:
+
+```json
+"ts-builds": "^3.0.0"
+```
+
+### Step 2: Run the doctor fix
+
+```bash
+pnpm exec ts-builds doctor --fix
+```
+
+This performs the mechanical config migration automatically:
+
+- Relocates `public-hoist-pattern[]` from `.npmrc` into `pnpm-workspace.yaml` as `publicHoistPattern`
+- Relocates `overrides` and `peerDependencyRules` from the `package.json` `pnpm` field into `pnpm-workspace.yaml`
+- Strips the inert `.npmrc` lines
+- Prunes the `package.json` `pnpm` field
+
+Exotic `pnpm` keys (e.g. `packageExtensions`) and pre-existing target keys are reported for manual migration rather than altered.
+
+### Step 3: Switch pnpm to version 11
+
+```bash
+corepack use pnpm@11
+```
+
+**Known gotcha — non-interactive shell abort:**
+
+In a non-interactive shell (CI, subprocess), this command may abort with:
+
+```
+ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY
+```
+
+This happens because the pnpm 11 store migration purges `node_modules` and requires a TTY confirmation prompt. Recover by re-running the install with `CI=true`:
+
+```bash
+CI=true pnpm install
+```
+
+The lockfile remains at `lockfileVersion: 9.0` — this is expected.
+
+### Step 4: Resolve ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION
+
+pnpm 11's `minimumReleaseAge` default (1440 minutes / 1 day) refuses dependency versions published less than 24 hours ago. This only affects fresh `pnpm add` calls and lockfile re-resolutions — CI installs from a committed `pnpm-lock.yaml` are unaffected.
+
+**Error pattern:**
+
+```
+ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION
+```
+
+**Fix:** Add an `minimumReleaseAgeExclude` list to `pnpm-workspace.yaml`.
+
+Two forms are accepted:
+
+- **Pinned `pkg@version`** — exclude a specific just-published version. Use when the semver range resolves to a version that has no aged-enough alternative. Do NOT downgrade instead — a pinned exclude is the correct response. Example: if `@types/node@^24.13.1` resolves only to `@types/node@24.13.1` (just published), add the pinned form.
+- **Bare `pkg`** — exclude all versions of a package (all versions). Use for first-party libraries you control and trust, so you can install your own just-published packages without waiting 24 hours.
+
+```yaml
+# pnpm-workspace.yaml
+minimumReleaseAgeExclude:
+  - "@types/node@24.13.1"   # pinned: only this exact version excluded
+  - ts-builds               # bare: all versions — first-party, trusted
+  - functype                # bare: first-party
+  - functype-os             # bare: first-party (example functype sub-package)
+```
+
+Documented default set of bare (first-party) excludes: `ts-builds`, `functype`, and any `functype-*` packages you publish.
+
+### Step 5: Resolve ERR_PNPM_IGNORED_BUILDS
+
+pnpm 11's `strictDepBuilds: true` makes an un-approved dependency build script a **hard error** (pnpm 10 only warned).
+
+**Error pattern:**
+
+```
+ERR_PNPM_IGNORED_BUILDS
+```
+
+**Fix:** Add an `allowBuilds` map to `pnpm-workspace.yaml`. The map accepts package name → boolean: `true` approves the build script; `false` explicitly declines it (still suppresses the error).
+
+Real-world example: `esbuild` triggers this error, but its build script is NOT needed — its binary ships via `@esbuild/<platform>` optional dependencies. Setting `false` is correct and produces a green build:
+
+```yaml
+# pnpm-workspace.yaml
+allowBuilds:
+  esbuild: false        # build script not needed; binary via @esbuild/<platform> optional deps
+  some-native-pkg: true # approve a package that genuinely needs its build script
+```
+
+`esbuild: false` is the ts-builds default. Only set `true` for packages that genuinely require their build script to function.
+
+### Step 6: Validate
+
+Run a clean install followed by the full validate chain:
+
+```bash
+pnpm install
+pnpm validate
+```
+
+Both must pass with no errors. If `pnpm validate` invokes the ts-builds validate chain, it runs format, lint, typecheck, test, and build in sequence.

--- a/.claude/skills/ts-builds/references/standardization.md
+++ b/.claude/skills/ts-builds/references/standardization.md
@@ -810,14 +810,14 @@ CI=true pnpm install
 
 The lockfile remains at `lockfileVersion: 9.0` — this is expected.
 
-### Step 4: Resolve ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION
+### Step 4: Resolve ERR_PNPM_NO_MATURE_MATCHING_VERSION
 
 pnpm 11's `minimumReleaseAge` default (1440 minutes / 1 day) refuses dependency versions published less than 24 hours ago. This only affects fresh `pnpm add` calls and lockfile re-resolutions — CI installs from a committed `pnpm-lock.yaml` are unaffected.
 
-**Error pattern:**
+**Error pattern** (verified against pnpm 11.5.2 — each flagged package is named with its `pkg@version`):
 
 ```
-ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION
+ ERR_PNPM_NO_MATURE_MATCHING_VERSION  <pkg>@<version> was published within the minimumReleaseAge cutoff
 ```
 
 **Fix:** Add an `minimumReleaseAgeExclude` list to `pnpm-workspace.yaml`.

--- a/.claude/skills/ts-builds/references/standardization.md
+++ b/.claude/skills/ts-builds/references/standardization.md
@@ -830,10 +830,10 @@ Two forms are accepted:
 ```yaml
 # pnpm-workspace.yaml
 minimumReleaseAgeExclude:
-  - "@types/node@24.13.1"   # pinned: only this exact version excluded
-  - ts-builds               # bare: all versions — first-party, trusted
-  - functype                # bare: first-party
-  - functype-os             # bare: first-party (example functype sub-package)
+  - "@types/node@24.13.1" # pinned: only this exact version excluded
+  - ts-builds # bare: all versions — first-party, trusted
+  - functype # bare: first-party
+  - functype-os # bare: first-party (example functype sub-package)
 ```
 
 Documented default set of bare (first-party) excludes: `ts-builds`, `functype`, and any `functype-*` packages you publish.
@@ -855,7 +855,7 @@ Real-world example: `esbuild` triggers this error, but its build script is NOT n
 ```yaml
 # pnpm-workspace.yaml
 allowBuilds:
-  esbuild: false        # build script not needed; binary via @esbuild/<platform> optional deps
+  esbuild: false # build script not needed; binary via @esbuild/<platform> optional deps
   some-native-pkg: true # approve a package that genuinely needs its build script
 ```
 

--- a/.claude/skills/ts-builds/references/standardization.md
+++ b/.claude/skills/ts-builds/references/standardization.md
@@ -14,7 +14,7 @@ The fastest way to standardize a project is using the ts-builds CLI:
 # Install ts-builds (bundles all tooling)
 pnpm add -D ts-builds tsdown
 
-# Initialize (creates .npmrc with hoist patterns)
+# Initialize (creates pnpm-workspace.yaml with hoist patterns)
 npx ts-builds init
 
 # Remove redundant dependencies

--- a/.claude/skills/ts-builds/references/template-setup.md
+++ b/.claude/skills/ts-builds/references/template-setup.md
@@ -32,7 +32,7 @@ pnpm init
 # Install ts-builds (bundles all tooling)
 pnpm add -D ts-builds tsdown
 
-# Initialize (creates .npmrc with hoist patterns)
+# Initialize (creates pnpm-workspace.yaml with hoist patterns)
 npx ts-builds init
 
 # Create source directory

--- a/.claude/skills/ts-builds/references/tooling-reference.md
+++ b/.claude/skills/ts-builds/references/tooling-reference.md
@@ -10,7 +10,7 @@ ts-builds provides a CLI that runs standardized commands across all projects.
 
 ```bash
 npx ts-builds            # Default: runs init
-npx ts-builds init       # Initialize .npmrc with hoist patterns (run first)
+npx ts-builds init       # Initialize pnpm-workspace.yaml with hoist patterns (run first)
 npx ts-builds config     # Create ts-builds.config.json
 npx ts-builds config --force  # Overwrite existing config (or -f)
 npx ts-builds info       # Show bundled packages you don't need to install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,27 @@ lines in `.npmrc` and a `package.json` `pnpm` field (both ignored by pnpm 11).
 `pnpm` field. Exotic `pnpm` keys (e.g. `packageExtensions`) and pre-existing target
 keys are reported for manual migration rather than altered.
 
+`doctor` also surfaces the two pnpm 11 supply-chain settings that need judgment:
+
+- **`minimumReleaseAge` violations** — a `minimumReleaseAge` check shells out to a
+  side-effect-free `pnpm install --resolution-only` probe (the lockfile is
+  snapshotted and restored, so `doctor` never rewrites it; if pnpm is absent the
+  probe degrades quietly) and reports the real error `ERR_PNPM_NO_MATURE_MATCHING_VERSION`.
+  Each flagged `pkg@version` is surfaced with a suggested `minimumReleaseAgeExclude`
+  line. `--fix` appends/merges those entries into `pnpm-workspace.yaml` — pinned
+  `pkg@version` for third-party deps with no aged-enough alternative, bare names for
+  first-party libs (`ts-builds`, `functype`, `functype-*`).
+- **`allowBuilds` gaps** — a static check (no install) compares a curated known-safe
+  set (`esbuild`) present in `pnpm-lock.yaml` against the `allowBuilds` keys already
+  in `pnpm-workspace.yaml`; an undecided build script (hard-errors as
+  `ERR_PNPM_IGNORED_BUILDS` under `strictDepBuilds`) is flagged with a suggested
+  `allowBuilds.esbuild: false` (esbuild's binary ships via `@esbuild/<platform>`
+  optional deps; its build script is not needed). `--fix` writes/merges that map.
+
+Both `--fix` additions preserve existing `pnpm-workspace.yaml` content, never
+duplicate a top-level key, and are idempotent. The release-age detection lives
+behind an injectable probe (`PnpmReleaseAgeProbe`) for testability.
+
 ### Deprecation (since 2.8.0)
 
 `commands["validate:X"]` entries with a `cwd:` that escapes the package root emit a deprecation warning at config load (deduplicated per `name × cwd` pair) and are targeted for removal in **ts-builds 4.0**. Use a workspace orchestrator (Turbo, nx, `pnpm -r`) for cross-package validation instead. See issue #72.

--- a/docs/superpowers/plans/2026-06-06-pnpm11-skill-and-doctor-ownership.md
+++ b/docs/superpowers/plans/2026-06-06-pnpm11-skill-and-doctor-ownership.md
@@ -1,0 +1,88 @@
+# pnpm 11 Knowledge Ownership: Skill Sync + Doctor Guidance
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make ts-builds the single source of truth for the pnpm 11 migration story. Two surfaces are out of sync with the 3.0.0 reality: (A) the **agent-facing skill** (`SKILL.md` + `references/`) still teaches pre-3.0.0 `.npmrc` behavior and says nothing about pnpm 11's on-by-default supply-chain settings; (B) `doctor` automates only the *mechanical* part of the migration (hoist patterns + `pnpm` field) and gives no guidance on the two parts that actually require judgment — `minimumReleaseAge` violations and the `allowBuilds` / ignored-builds decision.
+
+**Why now:** A real envpkt migration (2026-06-06) exercised the full 2.8.2→3.0.0 / pnpm 10→11 path. The mechanical relocation (`doctor --fix`) worked perfectly, but the agent began the session with **stale skill guidance** (believed `init` writes `.npmrc`) and had to hand-resolve the `minimumReleaseAge` exclude (`@types/node@24.13.1`, no aged alternative in range) and the `allowBuilds.esbuild: false` decision with no tool support. Those gaps are reproducible for every consumer.
+
+**Tech Stack:** TypeScript, tsdown, Vitest, functype, Commander CLI, Claude Code plugin/skill (`.claude/skills/ts-builds/`). No MCP server (ts-builds is CLI + skill only).
+
+## Verified facts (sources)
+
+- pnpm 11 enables **supply-chain protection by default**: `minimumReleaseAge` defaults to **1440** (1 day), `blockExoticSubdeps: true`, `strictDepBuilds: true`, `optimisticRepeatInstall: true`, `verifyDepsBeforeRun: install`. (pnpm.io blog releases/11.0 — "Supply-chain protection on by default" + "Breaking changes > Security & build defaults")
+- `pnpm config get minimumReleaseAge` returns `undefined` even though the policy is active — it is a **built-in default, not an explicit setting**. (observed in envpkt migration; install failed `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`)
+- `allowBuilds` (added v10.26.0) **replaces** `onlyBuiltDependencies` / `onlyBuiltDependenciesFile` / `neverBuiltDependencies` / `ignoredBuiltDependencies` / `ignoreDepScripts` in v11. It is a map of package matcher → boolean in `pnpm-workspace.yaml`. (pnpm.io settings + releases/11.0)
+- Ignored build scripts are a **hard error** (`ERR_PNPM_IGNORED_BUILDS`) under `strictDepBuilds: true`, not pnpm 10's soft warning. (observed)
+- `esbuild`'s build script is **not needed** — its binary ships via `@esbuild/<platform>` optional deps; `allowBuilds.esbuild: false` is correct (verified by a green build). (observed)
+- `corepack use pnpm@11` aborts the reinstall with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` in non-interactive shells (store-v11 re-fetch purges `node_modules`); re-run install with `CI=true`. Lockfile stays `lockfileVersion: 9.0`. (observed)
+- `minimumReleaseAgeExclude` accepts pinned `pkg@version` and bare `pkg` (all versions); when a dep's semver range has no aged-enough version (e.g. `@types/node@^24.13.1`), a pinned exclude is the correct fix, not a downgrade. (pnpm.io releases/10.19 + observed)
+
+## Current state (observed 2026-06-06)
+
+- `SKILL.md:39,59,75` — three `npx ts-builds init # Creates .npmrc with hoist patterns` lines (stale; 3.0.0 writes `pnpm-workspace.yaml`).
+- `.claude/skills/ts-builds/references/standardization.md:17`, `template-setup.md:35`, `tooling-reference.md:13` — same stale `.npmrc` init comment.
+- `SKILL.md` + all three `references/*.md` — **0** mentions of pnpm 11 / `minimumReleaseAge` / `allowBuilds` / `pnpm-workspace.yaml`.
+- `README.md` (3 mentions) and `CLAUDE.md` (14 mentions) — already updated for pnpm 11; treat as the canonical prose to mirror into the skill.
+- `src/cli/pnpm11.ts` — `detectPnpm11Issues()` checks only `.npmrc` hoist patterns (`pnpm11.ts:24-28`) + `package.json` `pnpm` field (`:38`); `migratePnpm11()` relocates hoist patterns / overrides / peerDependencyRules only (`:135,:151`). No `minimumReleaseAge` or ignored-builds awareness.
+- `src/cli/commands/doctor.ts:210` wires `detectPnpm11Issues()`; `:245` runs `migratePnpm11()` on `--fix`.
+
+## Non-goals
+
+- Re-documenting pnpm 11 in `README.md` / `CLAUDE.md` (already done).
+- Building an MCP server.
+- Changing the existing hoist-pattern / `pnpm`-field migration behavior (it works).
+
+---
+
+## Phase A — Sync the agent-facing skill (doc-only, low risk)
+
+### Task A1: De-stale the `.npmrc` references
+
+- [ ] Replace the 6 `init ... .npmrc` lines (`SKILL.md:39,59,75`; `standardization.md:17`; `template-setup.md:35`; `tooling-reference.md:13`) with the 3.0.0 reality: `init` writes `pnpm-workspace.yaml` (`publicHoistPattern`); `.npmrc` is auth/registry-only under pnpm 11.
+- [ ] Grep-verify zero remaining stale references: `grep -rn "\.npmrc\|public-hoist-pattern" .claude/skills/` returns only intentional auth/registry mentions.
+
+### Task A2: Add a "pnpm 11 defaults" section to `SKILL.md`
+
+- [ ] Document the on-by-default settings (`minimumReleaseAge: 1440`, `strictDepBuilds`, `blockExoticSubdeps`) and the `pnpm-workspace.yaml` config surface (`publicHoistPattern`, `minimumReleaseAgeExclude`, `allowBuilds`).
+- [ ] Note `allowBuilds` replaced the legacy `onlyBuiltDependencies` family, and `esbuild: false` is the correct/default choice.
+
+### Task A3: Add a "Migrating 2.x → 3.0.0 / pnpm 10 → 11" runbook to `references/standardization.md`
+
+- [ ] Step-by-step capturing the verified gotchas: bump ts-builds → `^3.0.0`; `doctor --fix` (relocates hoist patterns); `corepack use pnpm@11` then `CI=true pnpm install`; resolve `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` by adding the flagged `pkg@version` (+ first-party libs) to `minimumReleaseAgeExclude`; resolve `ERR_PNPM_IGNORED_BUILDS` via `allowBuilds`; validate.
+- [ ] Cross-reference from `SKILL.md` so an agent loading the skill finds the runbook.
+
+### Task A4: Release so the skill cache refreshes
+
+- [ ] The skill is consumed from the plugin cache; cut a ts-builds release (or document the cache-refresh step) so updated skill content reaches sessions. Verify `npx ts-builds@latest` carries the synced docs.
+
+---
+
+## Phase B — Extend `doctor` to guide the judgment calls (feature, needs TDD + release)
+
+### Task B1: Detect `minimumReleaseAge` violations in `detectPnpm11Issues()`
+
+- [ ] Run a non-mutating policy check (shell `pnpm install --frozen-lockfile`/equivalent, capture `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` entries) and surface each flagged `pkg@version` as a `CheckResult` warning with the suggested `minimumReleaseAgeExclude` line. (Design decision to lock in the plan: shell-out vs. parse lockfile timestamps against a 1440 default.)
+- [ ] Tests: fixture with a too-fresh lockfile entry → warning lists the exact `pkg@version`.
+
+### Task B2: Detect ignored builds / `allowBuilds` gaps
+
+- [ ] Detect packages with un-decided build scripts (the `ERR_PNPM_IGNORED_BUILDS` set) and surface an `allowBuilds` scaffold suggestion, defaulting known-safe tools (e.g. `esbuild: false`) with a rationale.
+- [ ] Tests: fixture with esbuild present and no `allowBuilds` → warning proposes `allowBuilds.esbuild: false`.
+
+### Task B3: Wire both into `migratePnpm11()` / `doctor --fix`
+
+- [ ] `--fix` appends the flagged `minimumReleaseAgeExclude` entries (pinned `pkg@version` for no-aged-alternative deps; bare names for first-party libs) and the `allowBuilds` map to `pnpm-workspace.yaml`, preserving existing content and the deferred-source-mutation safety pattern already in `migratePnpm11()`.
+- [ ] Tests: `--fix` on a fixture produces a `pnpm-workspace.yaml` that passes `pnpm install` clean.
+
+### Task B4: Validate + release
+
+- [ ] `pnpm validate` green; bump + publish; confirm `doctor` / `doctor --fix` guide a real consumer migration end-to-end.
+
+---
+
+## Suggested decisions to lock before implementing Phase B
+
+1. **minimumReleaseAge detection mechanism:** shell out to pnpm and parse the error (accurate, depends on pnpm in PATH) vs. read lockfile publish timestamps against the 1440 default (no shell-out, must track the default). Recommend shell-out — it tracks pnpm's actual policy including future default changes.
+2. **First-party exclude list:** hardcode a sensible default (`ts-builds`, `functype`/`functype-*`) vs. infer from `dependencies`. Recommend a documented default that consumers can extend.
+3. **Scope of `allowBuilds` defaults:** only suggest `false` for a curated known-safe set (esbuild) and leave everything else for explicit human decision.

--- a/docs/superpowers/plans/2026-06-06-pnpm11-skill-and-doctor-ownership.md
+++ b/docs/superpowers/plans/2026-06-06-pnpm11-skill-and-doctor-ownership.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make ts-builds the single source of truth for the pnpm 11 migration story. Two surfaces are out of sync with the 3.0.0 reality: (A) the **agent-facing skill** (`SKILL.md` + `references/`) still teaches pre-3.0.0 `.npmrc` behavior and says nothing about pnpm 11's on-by-default supply-chain settings; (B) `doctor` automates only the *mechanical* part of the migration (hoist patterns + `pnpm` field) and gives no guidance on the two parts that actually require judgment — `minimumReleaseAge` violations and the `allowBuilds` / ignored-builds decision.
+**Goal:** Make ts-builds the single source of truth for the pnpm 11 migration story. Two surfaces are out of sync with the 3.0.0 reality: (A) the **agent-facing skill** (`SKILL.md` + `references/`) still teaches pre-3.0.0 `.npmrc` behavior and says nothing about pnpm 11's on-by-default supply-chain settings; (B) `doctor` automates only the _mechanical_ part of the migration (hoist patterns + `pnpm` field) and gives no guidance on the two parts that actually require judgment — `minimumReleaseAge` violations and the `allowBuilds` / ignored-builds decision.
 
 **Why now:** A real envpkt migration (2026-06-06) exercised the full 2.8.2→3.0.0 / pnpm 10→11 path. The mechanical relocation (`doctor --fix`) worked perfectly, but the agent began the session with **stale skill guidance** (believed `init` writes `.npmrc`) and had to hand-resolve the `minimumReleaseAge` exclude (`@types/node@24.13.1`, no aged alternative in range) and the `allowBuilds.esbuild: false` decision with no tool support. Those gaps are reproducible for every consumer.
 
@@ -11,7 +11,7 @@
 ## Verified facts (sources)
 
 - pnpm 11 enables **supply-chain protection by default**: `minimumReleaseAge` defaults to **1440** (1 day), `blockExoticSubdeps: true`, `strictDepBuilds: true`, `optimisticRepeatInstall: true`, `verifyDepsBeforeRun: install`. (pnpm.io blog releases/11.0 — "Supply-chain protection on by default" + "Breaking changes > Security & build defaults")
-- `pnpm config get minimumReleaseAge` returns `undefined` even though the policy is active — it is a **built-in default, not an explicit setting**. (observed in envpkt migration; install failed `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`)
+- `pnpm config get minimumReleaseAge` returns `undefined` even though the policy is active — it is a **built-in default, not an explicit setting**. (observed in envpkt migration; install failed `ERR_PNPM_NO_MATURE_MATCHING_VERSION`)
 - `allowBuilds` (added v10.26.0) **replaces** `onlyBuiltDependencies` / `onlyBuiltDependenciesFile` / `neverBuiltDependencies` / `ignoredBuiltDependencies` / `ignoreDepScripts` in v11. It is a map of package matcher → boolean in `pnpm-workspace.yaml`. (pnpm.io settings + releases/11.0)
 - Ignored build scripts are a **hard error** (`ERR_PNPM_IGNORED_BUILDS`) under `strictDepBuilds: true`, not pnpm 10's soft warning. (observed)
 - `esbuild`'s build script is **not needed** — its binary ships via `@esbuild/<platform>` optional deps; `allowBuilds.esbuild: false` is correct (verified by a green build). (observed)
@@ -49,7 +49,7 @@
 
 ### Task A3: Add a "Migrating 2.x → 3.0.0 / pnpm 10 → 11" runbook to `references/standardization.md`
 
-- [ ] Step-by-step capturing the verified gotchas: bump ts-builds → `^3.0.0`; `doctor --fix` (relocates hoist patterns); `corepack use pnpm@11` then `CI=true pnpm install`; resolve `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` by adding the flagged `pkg@version` (+ first-party libs) to `minimumReleaseAgeExclude`; resolve `ERR_PNPM_IGNORED_BUILDS` via `allowBuilds`; validate.
+- [ ] Step-by-step capturing the verified gotchas: bump ts-builds → `^3.0.0`; `doctor --fix` (relocates hoist patterns); `corepack use pnpm@11` then `CI=true pnpm install`; resolve `ERR_PNPM_NO_MATURE_MATCHING_VERSION` by adding the flagged `pkg@version` (+ first-party libs) to `minimumReleaseAgeExclude`; resolve `ERR_PNPM_IGNORED_BUILDS` via `allowBuilds`; validate.
 - [ ] Cross-reference from `SKILL.md` so an agent loading the skill finds the runbook.
 
 ### Task A4: Release so the skill cache refreshes
@@ -62,7 +62,7 @@
 
 ### Task B1: Detect `minimumReleaseAge` violations in `detectPnpm11Issues()`
 
-- [ ] Run a non-mutating policy check (shell `pnpm install --frozen-lockfile`/equivalent, capture `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` entries) and surface each flagged `pkg@version` as a `CheckResult` warning with the suggested `minimumReleaseAgeExclude` line. (Design decision to lock in the plan: shell-out vs. parse lockfile timestamps against a 1440 default.)
+- [ ] Run a non-mutating policy check (shell `pnpm install --frozen-lockfile`/equivalent, capture `ERR_PNPM_NO_MATURE_MATCHING_VERSION` entries) and surface each flagged `pkg@version` as a `CheckResult` warning with the suggested `minimumReleaseAgeExclude` line. (Design decision to lock in the plan: shell-out vs. parse lockfile timestamps against a 1440 default.)
 - [ ] Tests: fixture with a too-fresh lockfile entry → warning lists the exact `pkg@version`.
 
 ### Task B2: Detect ignored builds / `allowBuilds` gaps

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-builds",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Shared TypeScript configuration files for library templates. Provides standardized ESLint, Prettier, Vitest, TypeScript, and build configs.",
   "keywords": [
     "typescript",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,3 @@
-import { loadConfig } from "./cli/config"
-import { runCommand, runShellCommand } from "./cli/process"
-import { runValidate } from "./cli/runner"
 import { runBuild, runDev, runFormat, runLint, runTest, runTypecheck } from "./cli/commands/build"
 import { runChangelog } from "./cli/commands/changelog"
 import { cleanup } from "./cli/commands/cleanup"
@@ -8,6 +5,9 @@ import { runDoctor } from "./cli/commands/doctor"
 import { showHelp, showInfo } from "./cli/commands/info"
 import { createConfig, init } from "./cli/commands/init"
 import { runSize } from "./cli/commands/size"
+import { loadConfig } from "./cli/config"
+import { runCommand, runShellCommand } from "./cli/process"
+import { runValidate } from "./cli/runner"
 
 const command = process.argv[2] || "init"
 const subCommand = process.argv[3]

--- a/src/cli/commands/changelog.ts
+++ b/src/cli/commands/changelog.ts
@@ -178,7 +178,7 @@ function formatMarkdown(grouped: GroupedChangelog, repoUrl: Option<string>, vers
   )
   lines.push("")
 
-  if (grouped.breaking.nonEmpty) {
+  if (!grouped.breaking.isEmpty) {
     lines.push("### BREAKING CHANGES")
     lines.push("")
     for (const commit of grouped.breaking) {

--- a/src/cli/pnpm11.ts
+++ b/src/cli/pnpm11.ts
@@ -51,20 +51,39 @@ export function buildReleaseAgeExcludeLine(pkgVersion: string): string {
 
 /**
  * Default probe: runs `pnpm install --resolution-only`, which re-runs resolution
- * (re-applying minimumReleaseAge) WITHOUT writing a lockfile or node_modules — it
- * aborts before any mutation on a violation. If pnpm is not on PATH the spawn
- * errors and we return status -1 so detection degrades quietly.
+ * (re-applying minimumReleaseAge) and captures its output. If pnpm is not on PATH
+ * the spawn errors and we return status -1 so detection degrades quietly.
+ *
+ * SNAPSHOT/RESTORE: `--resolution-only` is NOT non-mutating in general. When the
+ * committed `pnpm-lock.yaml` is stale or doesn't match resolution, pnpm REWRITES
+ * it to match (it only avoids writing when it ABORTS on a violation). A read-only
+ * diagnostic must never touch a consumer's lockfile, so we snapshot the exact
+ * bytes before spawning and restore them in a `finally` — putting the file back
+ * exactly as found (or removing one the probe created where none existed).
+ * `--resolution-only` does not install packages, so node_modules is not a concern.
  */
 export const defaultReleaseAgeProbe: PnpmReleaseAgeProbe = (dir) => {
-  const result = spawnSync("pnpm", ["install", "--resolution-only"], {
-    cwd: dir,
-    encoding: "utf-8",
-    env: process.env,
-  })
-  if (result.error) {
-    return { stdout: "", stderr: "", status: -1 }
+  const lockPath = join(dir, "pnpm-lock.yaml")
+  const lockExisted = existsSync(lockPath)
+  // readFileSync without an encoding yields a Buffer, preserving bytes exactly.
+  const originalLock = lockExisted ? readFileSync(lockPath) : undefined
+  try {
+    const result = spawnSync("pnpm", ["install", "--resolution-only"], {
+      cwd: dir,
+      encoding: "utf-8",
+      env: process.env,
+    })
+    if (result.error) {
+      return { stdout: "", stderr: "", status: -1 }
+    }
+    return { stdout: result.stdout ?? "", stderr: result.stderr ?? "", status: result.status ?? 1 }
+  } finally {
+    if (lockExisted && originalLock !== undefined) {
+      writeFileSync(lockPath, originalLock)
+    } else if (!lockExisted && existsSync(lockPath)) {
+      rmSync(lockPath, { force: true })
+    }
   }
-  return { stdout: result.stdout ?? "", stderr: result.stderr ?? "", status: result.status ?? 1 }
 }
 
 // ─── B2: allowBuilds / esbuild detection ────────────────────────────────────
@@ -399,6 +418,12 @@ export function migratePnpm11(
   let ws = wsExists ? readFileSync(wsPath, "utf-8") : ""
   let wsChanged = false
 
+  // Read pnpm-lock.yaml ONCE, up front — BEFORE block (c)'s probe runs. The probe
+  // can rewrite the consumer lockfile (see defaultReleaseAgeProbe), so block (d)
+  // below must decide allowBuilds from this snapshot, not a re-read after the probe.
+  const lockPath = join(dir, "pnpm-lock.yaml")
+  const lockfile = existsSync(lockPath) ? readFileSync(lockPath, "utf-8") : undefined
+
   // (a) .npmrc hoist patterns -> pnpm-workspace.yaml
   const npmrcPath = join(dir, ".npmrc")
   if (existsSync(npmrcPath)) {
@@ -545,9 +570,9 @@ export function migratePnpm11(
 
   // (d) allowBuilds — write `<pkg>: false` for curated packages present in the
   // lockfile and not already decided. Same additive, single-write discipline.
-  const lockPath = join(dir, "pnpm-lock.yaml")
-  if (existsSync(lockPath)) {
-    const lockfile = readFileSync(lockPath, "utf-8")
+  // Uses the lockfile snapshot read at the top (before block c's probe ran), so
+  // it is unaffected by any probe-time lockfile rewrite.
+  if (lockfile !== undefined) {
     const decided = readAllowBuildsKeys(ws)
     const toAdd: Array<[string, string]> = []
     for (const pkg of CURATED_ALLOW_BUILDS_FALSE.keys()) {

--- a/src/cli/pnpm11.ts
+++ b/src/cli/pnpm11.ts
@@ -18,10 +18,11 @@ export type PnpmReleaseAgeProbe = (dir: string) => { stdout: string; stderr: str
 
 // Each per-violation line pnpm prints looks like:
 //   left-pad@1.3.0 was published at 2018-04-09T01:10:45.796Z, within the minimumReleaseAge cutoff (...)
-// Matching the line directly (rather than the header error code) keeps us robust
-// across pnpm's two known marker codes: ERR_PNPM_NO_MATURE_MATCHING_VERSION (11.5.x)
-// and ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION. The package token is `name@version`,
-// where name may be scoped (`@scope/name`).
+// Verified against pnpm 11.5.2: the failure surfaces under the error code
+// ERR_PNPM_NO_MATURE_MATCHING_VERSION. We match the per-violation LINE rather than
+// the header code so we stay robust to message-format/code changes across pnpm
+// releases. The package token is `name@version`, where name may be scoped
+// (`@scope/name`).
 const RELEASE_AGE_LINE = /(@?[^\s@/]+(?:\/[^\s@]+)?@[^\s]+)\s+was published.*minimumReleaseAge/
 
 /**

--- a/src/cli/pnpm11.ts
+++ b/src/cli/pnpm11.ts
@@ -275,6 +275,105 @@ function renderPeerDependencyRules(rules: NonNullable<PnpmField["peerDependencyR
   return lines.join("\n") + "\n"
 }
 
+/**
+ * Packages we own and publish frequently; a release-age violation on these is
+ * almost always "I just published it" rather than a supply-chain concern, so we
+ * exclude by BARE name (all versions). Everything else is pinned to the exact
+ * flagged version. Match by NAME only — `ts-builds`, `functype`, `functype-*`.
+ */
+function isFirstParty(name: string): boolean {
+  return name === "ts-builds" || name === "functype" || name.startsWith("functype-")
+}
+
+/** Strip the trailing `@version` from a `pkg@version` token, scope-aware. */
+function packageNameOf(token: string): string {
+  const at = token.lastIndexOf("@")
+  // Scoped names start with "@" at position 0; that leading "@" is not a separator.
+  return at > 0 ? token.slice(0, at) : token
+}
+
+/** The target exclude entry for a flagged token: bare name (first-party) or pinned token. */
+function releaseAgeExcludeEntry(token: string): string {
+  return isFirstParty(packageNameOf(token)) ? packageNameOf(token) : token
+}
+
+/** Render a list entry, quoting pinned `pkg@version` forms, leaving bare names unquoted. */
+function renderExcludeEntry(entry: string): string {
+  return entry.includes("@") ? `  - "${entry}"` : `  - ${entry}`
+}
+
+/**
+ * Pure parser: returns the set of entries already listed under
+ * `minimumReleaseAgeExclude:`, normalized (quotes stripped). Same manual
+ * line-by-line style as readAllowBuildsKeys — stops at the next top-level key.
+ */
+export function readReleaseAgeExcludeEntries(yaml: string): Set<string> {
+  const entries = new Set<string>()
+  let inBlock = false
+  for (const raw of yaml.split("\n")) {
+    const line = raw.trimEnd()
+    if (!inBlock) {
+      if (/^minimumReleaseAgeExclude:/.test(line)) {
+        inBlock = true
+      }
+      continue
+    }
+    if (/^[^\s#]/.test(line)) {
+      break
+    }
+    const m = /^\s*-\s*"?([^"]+?)"?\s*$/.exec(line)
+    if (m) {
+      entries.add(m[1])
+    }
+  }
+  return entries
+}
+
+/**
+ * Insert YAML list entries (already rendered as `  - x` lines) into an existing
+ * top-level block, after its last list item and before the next top-level key.
+ * Assumes the block exists; de-dup is the caller's responsibility.
+ */
+function insertListEntries(yaml: string, blockKey: string, renderedLines: string[]): string {
+  if (renderedLines.length === 0) return yaml
+  const lines = yaml.split("\n")
+  const startRe = new RegExp(`^${blockKey}:`)
+  let start = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (startRe.test(lines[i])) {
+      start = i
+      break
+    }
+  }
+  if (start === -1) return yaml
+  // The block runs until the next top-level key (non-space, non-comment start).
+  let end = lines.length
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^[^\s#]/.test(lines[i])) {
+      end = i
+      break
+    }
+  }
+  // Insert after the last non-empty line within the block.
+  let insertAt = start + 1
+  for (let i = start + 1; i < end; i++) {
+    if (lines[i].trim() !== "") {
+      insertAt = i + 1
+    }
+  }
+  lines.splice(insertAt, 0, ...renderedLines)
+  return lines.join("\n")
+}
+
+/** Insert `  <key>: <value>` map entries into an existing top-level block. */
+function insertMapEntries(yaml: string, blockKey: string, entries: Array<[string, string]>): string {
+  return insertListEntries(
+    yaml,
+    blockKey,
+    entries.map(([k, v]) => `  ${k}: ${v}`),
+  )
+}
+
 function safeWrite(path: string, content: string): boolean {
   try {
     writeFileSync(path, content)
@@ -284,7 +383,10 @@ function safeWrite(path: string, content: string): boolean {
   }
 }
 
-export function migratePnpm11(dir: string = targetDir): MigrationReport {
+export function migratePnpm11(
+  dir: string = targetDir,
+  releaseAgeProbe: PnpmReleaseAgeProbe = defaultReleaseAgeProbe,
+): MigrationReport {
   const actions: MigrationAction[] = []
   let errors = 0
   // Destructive edits to the SOURCE files are deferred until the destination
@@ -405,6 +507,65 @@ export function migratePnpm11(dir: string = targetDir): MigrationReport {
           }
         })
       }
+    }
+  }
+
+  // (c) minimumReleaseAgeExclude — append/merge flagged release-age violations.
+  // Pure additive: only ever ADDS to ws (never strips source), so no deferred
+  // sourceMutation is needed — it joins the same single ws write below.
+  const { stdout, stderr } = releaseAgeProbe(dir)
+  const violations = parseReleaseAgeViolations(stdout, stderr)
+  if (violations.length > 0) {
+    const existing = readReleaseAgeExcludeEntries(ws)
+    const newEntries: string[] = []
+    const seen = new Set<string>()
+    for (const token of violations) {
+      const entry = releaseAgeExcludeEntry(token)
+      // A bare first-party name already present suppresses a pinned form too,
+      // because readReleaseAgeExcludeEntries stores the normalized entry and
+      // releaseAgeExcludeEntry maps first-party tokens to that same bare name.
+      if (existing.has(entry) || seen.has(entry)) continue
+      seen.add(entry)
+      newEntries.push(entry)
+    }
+    if (newEntries.length > 0) {
+      const rendered = newEntries.map(renderExcludeEntry)
+      if (hasTopLevelKey(ws, "minimumReleaseAgeExclude")) {
+        ws = insertListEntries(ws, "minimumReleaseAgeExclude", rendered)
+      } else {
+        ws = appendBlock(ws, "minimumReleaseAgeExclude:\n" + rendered.join("\n") + "\n")
+      }
+      wsChanged = true
+      actions.push({
+        kind: "migrated",
+        message: `Added ${newEntries.length} minimumReleaseAgeExclude entr${newEntries.length === 1 ? "y" : "ies"}`,
+      })
+    }
+  }
+
+  // (d) allowBuilds — write `<pkg>: false` for curated packages present in the
+  // lockfile and not already decided. Same additive, single-write discipline.
+  const lockPath = join(dir, "pnpm-lock.yaml")
+  if (existsSync(lockPath)) {
+    const lockfile = readFileSync(lockPath, "utf-8")
+    const decided = readAllowBuildsKeys(ws)
+    const toAdd: Array<[string, string]> = []
+    for (const pkg of CURATED_ALLOW_BUILDS_FALSE.keys()) {
+      if (decided.has(pkg)) continue
+      if (!LOCKFILE_PKG_PRESENCE(pkg).test(lockfile)) continue
+      toAdd.push([pkg, "false"])
+    }
+    if (toAdd.length > 0) {
+      if (hasTopLevelKey(ws, "allowBuilds")) {
+        ws = insertMapEntries(ws, "allowBuilds", toAdd)
+      } else {
+        ws = appendBlock(ws, "allowBuilds:\n" + toAdd.map(([k, v]) => `  ${k}: ${v}`).join("\n") + "\n")
+      }
+      wsChanged = true
+      actions.push({
+        kind: "migrated",
+        message: `Added ${toAdd.length} allowBuilds entr${toAdd.length === 1 ? "y" : "ies"}`,
+      })
     }
   }
 

--- a/src/cli/pnpm11.ts
+++ b/src/cli/pnpm11.ts
@@ -67,6 +67,88 @@ export const defaultReleaseAgeProbe: PnpmReleaseAgeProbe = (dir) => {
   return { stdout: result.stdout ?? "", stderr: result.stderr ?? "", status: result.status ?? 1 }
 }
 
+// ─── B2: allowBuilds / esbuild detection ────────────────────────────────────
+
+/**
+ * Curated set of packages whose build scripts are known to be unnecessary under
+ * pnpm 11's strictDepBuilds. Extend ONLY after verification — this list drives
+ * automatic suggestions; wrong entries generate misleading doctor output.
+ *
+ * esbuild: binary ships via @esbuild/<platform> optional deps; build script not needed.
+ */
+const CURATED_ALLOW_BUILDS_FALSE: ReadonlyMap<string, string> = new Map([
+  ["esbuild", "binary ships via @esbuild/<platform> optional deps; build script not needed"],
+])
+
+/** Presence signal: the package appears as a resolved key in the lockfile. */
+const LOCKFILE_PKG_PRESENCE = (name: string): RegExp => new RegExp(`(^|[/'"\\s])${name}@`, "m")
+
+/**
+ * Pure parser: returns the set of package names already keyed under the
+ * `allowBuilds:` block in a `pnpm-workspace.yaml` string. Uses the same
+ * manual line-by-line style as the rest of this file — no yaml library.
+ *
+ * Stops collecting when it hits the next top-level key (line that starts with
+ * a non-whitespace char and ends with `:`).
+ */
+export function readAllowBuildsKeys(yaml: string): Set<string> {
+  const keys = new Set<string>()
+  let inBlock = false
+  for (const raw of yaml.split("\n")) {
+    const line = raw.trimEnd()
+    if (!inBlock) {
+      if (/^allowBuilds:/.test(line)) {
+        inBlock = true
+      }
+      continue
+    }
+    // A new top-level key ends the block (non-space start, ends with colon)
+    if (/^[^\s#]/.test(line)) {
+      break
+    }
+    // Indented entry: "  <name>: <bool>"
+    const m = /^\s{1,}([^\s:]+)\s*:/.exec(line)
+    if (m) {
+      keys.add(m[1])
+    }
+  }
+  return keys
+}
+
+function detectAllowBuildsIssues(dir: string): CheckResult[] {
+  const lockPath = join(dir, "pnpm-lock.yaml")
+  if (!existsSync(lockPath)) {
+    return []
+  }
+  const lockfile = readFileSync(lockPath, "utf-8")
+
+  const wsPath = join(dir, "pnpm-workspace.yaml")
+  const wsContent = existsSync(wsPath) ? readFileSync(wsPath, "utf-8") : ""
+  const decided = readAllowBuildsKeys(wsContent)
+
+  const results: CheckResult[] = []
+  for (const [pkg, rationale] of CURATED_ALLOW_BUILDS_FALSE) {
+    if (decided.has(pkg)) {
+      // Already decided (true or false) — nothing to report.
+      continue
+    }
+    if (!LOCKFILE_PKG_PRESENCE(pkg).test(lockfile)) {
+      // Not present in the lockfile — not applicable.
+      continue
+    }
+    results.push({
+      severity: "warning",
+      message:
+        `${pkg} has an un-decided build script under pnpm 11 strictDepBuilds — ` +
+        `this will hard-error (ERR_PNPM_IGNORED_BUILDS) on install.\n` +
+        `      Suggested addition to pnpm-workspace.yaml:\n` +
+        `        allowBuilds:\n` +
+        `          ${pkg}: false   # ${rationale}`,
+    })
+  }
+  return results
+}
+
 function detectReleaseAgeIssues(dir: string, probe: PnpmReleaseAgeProbe): CheckResult[] {
   // Only meaningful where pnpm has something to resolve. A bare tmpdir with no
   // lockfile/manifest context yields nothing to flag; the probe degrades to empty.
@@ -113,6 +195,10 @@ export function detectPnpm11Issues(
         message: `package.json 'pnpm' field is no longer read by pnpm 11 — run 'ts-builds doctor --fix' to migrate to pnpm-workspace.yaml`,
       })
     }
+  }
+
+  for (const allowBuildsIssue of detectAllowBuildsIssues(dir)) {
+    results.push(allowBuildsIssue)
   }
 
   for (const releaseAgeIssue of detectReleaseAgeIssues(dir, releaseAgeProbe)) {

--- a/src/cli/pnpm11.ts
+++ b/src/cli/pnpm11.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process"
 import { existsSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 
@@ -8,6 +9,76 @@ import { targetDir } from "./config"
 
 const HOIST_LINE = /^public-hoist-pattern\[\]=(.+)$/
 
+/**
+ * The impure edge of release-age detection: runs a non-mutating pnpm resolution
+ * pass and captures its output. Injectable so tests can feed canned pnpm stderr
+ * without shelling out. Returns -1 status when pnpm cannot be spawned at all.
+ */
+export type PnpmReleaseAgeProbe = (dir: string) => { stdout: string; stderr: string; status: number }
+
+// Each per-violation line pnpm prints looks like:
+//   left-pad@1.3.0 was published at 2018-04-09T01:10:45.796Z, within the minimumReleaseAge cutoff (...)
+// Matching the line directly (rather than the header error code) keeps us robust
+// across pnpm's two known marker codes: ERR_PNPM_NO_MATURE_MATCHING_VERSION (11.5.x)
+// and ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION. The package token is `name@version`,
+// where name may be scoped (`@scope/name`).
+const RELEASE_AGE_LINE = /(@?[^\s@/]+(?:\/[^\s@]+)?@[^\s]+)\s+was published.*minimumReleaseAge/
+
+/**
+ * Pure parser (no I/O): extracts the flagged `pkg@version` tokens from captured
+ * pnpm output. Order-preserving and de-duplicated. Returns [] for unrelated or
+ * empty output so callers never emit false warnings.
+ */
+export function parseReleaseAgeViolations(stdout: string, stderr: string): string[] {
+  const combined = `${stdout}\n${stderr}`
+  const seen = new Set<string>()
+  const tokens: string[] = []
+  for (const line of combined.split("\n")) {
+    const m = RELEASE_AGE_LINE.exec(line.trim())
+    if (m && !seen.has(m[1])) {
+      seen.add(m[1])
+      tokens.push(m[1])
+    }
+  }
+  return tokens
+}
+
+/** Pure helper: the suggested pnpm-workspace.yaml exclude line for a flagged token. */
+export function buildReleaseAgeExcludeLine(pkgVersion: string): string {
+  return `minimumReleaseAgeExclude:\n  - "${pkgVersion}"`
+}
+
+/**
+ * Default probe: runs `pnpm install --resolution-only`, which re-runs resolution
+ * (re-applying minimumReleaseAge) WITHOUT writing a lockfile or node_modules — it
+ * aborts before any mutation on a violation. If pnpm is not on PATH the spawn
+ * errors and we return status -1 so detection degrades quietly.
+ */
+export const defaultReleaseAgeProbe: PnpmReleaseAgeProbe = (dir) => {
+  const result = spawnSync("pnpm", ["install", "--resolution-only"], {
+    cwd: dir,
+    encoding: "utf-8",
+    env: process.env,
+  })
+  if (result.error) {
+    return { stdout: "", stderr: "", status: -1 }
+  }
+  return { stdout: result.stdout ?? "", stderr: result.stderr ?? "", status: result.status ?? 1 }
+}
+
+function detectReleaseAgeIssues(dir: string, probe: PnpmReleaseAgeProbe): CheckResult[] {
+  // Only meaningful where pnpm has something to resolve. A bare tmpdir with no
+  // lockfile/manifest context yields nothing to flag; the probe degrades to empty.
+  const { stdout, stderr } = probe(dir)
+  const violations = parseReleaseAgeViolations(stdout, stderr)
+  return violations.map((pkgVersion) => ({
+    severity: "warning" as const,
+    message:
+      `${pkgVersion} is newer than the pnpm minimumReleaseAge cutoff — ` +
+      `add to pnpm-workspace.yaml to allow it:\n      ${buildReleaseAgeExcludeLine(pkgVersion)}`,
+  }))
+}
+
 function readHoistPatterns(npmrc: string): string[] {
   return npmrc
     .split("\n")
@@ -16,7 +87,10 @@ function readHoistPatterns(npmrc: string): string[] {
     .map((m) => m[1])
 }
 
-export function detectPnpm11Issues(dir: string = targetDir): List<CheckResult> {
+export function detectPnpm11Issues(
+  dir: string = targetDir,
+  releaseAgeProbe: PnpmReleaseAgeProbe = defaultReleaseAgeProbe,
+): List<CheckResult> {
   const results: CheckResult[] = []
 
   const npmrcPath = join(dir, ".npmrc")
@@ -38,6 +112,10 @@ export function detectPnpm11Issues(dir: string = targetDir): List<CheckResult> {
         message: `package.json 'pnpm' field is no longer read by pnpm 11 — run 'ts-builds doctor --fix' to migrate to pnpm-workspace.yaml`,
       })
     }
+  }
+
+  for (const releaseAgeIssue of detectReleaseAgeIssues(dir, releaseAgeProbe)) {
+    results.push(releaseAgeIssue)
   }
 
   if (results.length === 0) {

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -17,7 +17,17 @@ export { runCommand, runSequence, runShellCommand } from "./process"
  * `runFn` is intentionally not exposed on `CommandDef` — user configs cannot
  * supply a runFn through ts-builds.config.json.
  */
-export type BuiltinCommand = CommandDef | { runFn: () => Promise<number> }
+export type RunFnCommand = { runFn: () => Promise<number> }
+export type BuiltinCommand = CommandDef | RunFnCommand
+
+/**
+ * Type guard for the internal `runFn` step shape. A plain `"runFn" in cmd`
+ * check leaves `cmd.runFn` typed `unknown` (CommandDef has no such key), so we
+ * assert the narrowed type explicitly.
+ */
+function isRunFnCommand(cmd: CommandDef | RunFnCommand): cmd is RunFnCommand {
+  return "runFn" in cmd
+}
 
 export function getBuiltinCommands(config: ResolvedConfig): Record<string, BuiltinCommand> {
   const eslintCmd = config.lint.useProjectEslint ? "npx eslint" : "eslint"
@@ -87,7 +97,7 @@ export async function runChain(
     const cwdLabel = "cwd" in cmdDef && cmdDef.cwd ? ` (in ${cmdDef.cwd})` : ""
     console.log(`\n▶ Running ${step}...${cwdLabel}`)
 
-    const code = "runFn" in cmdDef ? await cmdDef.runFn() : await runShellCommand(cmdDef.run, { cwd: cmdDef.cwd })
+    const code = isRunFnCommand(cmdDef) ? await cmdDef.runFn() : await runShellCommand(cmdDef.run, { cwd: cmdDef.cwd })
     if (code !== 0) {
       console.error(`\n✗ ${step} failed with exit code ${code}`)
       return code

--- a/test/pnpm11.spec.ts
+++ b/test/pnpm11.spec.ts
@@ -4,11 +4,21 @@ import { join } from "node:path"
 
 import { describe, expect, it } from "vitest"
 
-import { detectPnpm11Issues, migratePnpm11 } from "../src/cli/pnpm11"
+import type { PnpmReleaseAgeProbe } from "../src/cli/pnpm11"
+import {
+  buildReleaseAgeExcludeLine,
+  detectPnpm11Issues,
+  migratePnpm11,
+  parseReleaseAgeViolations,
+} from "../src/cli/pnpm11"
 
 function tmp(): string {
   return mkdtempSync(join(tmpdir(), "ts-builds-pnpm11-"))
 }
+
+// No-op probe so the non-release-age tests stay deterministic and never shell
+// out to real pnpm. Release-age behaviour is exercised by its own tests below.
+const noReleaseAgeProbe: PnpmReleaseAgeProbe = () => ({ stdout: "", stderr: "", status: 0 })
 
 describe("detectPnpm11Issues", () => {
   it("warns about public-hoist-pattern lines in .npmrc with a count", () => {
@@ -16,7 +26,7 @@ describe("detectPnpm11Issues", () => {
     try {
       writeFileSync(join(dir, ".npmrc"), "public-hoist-pattern[]=*eslint*\npublic-hoist-pattern[]=typescript\n")
       writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
-      const results = detectPnpm11Issues(dir).toArray()
+      const results = detectPnpm11Issues(dir, noReleaseAgeProbe).toArray()
       expect(results).toHaveLength(1)
       expect(results[0].severity).toBe("warning")
       expect(results[0].message).toContain("2 hoist pattern(s) in .npmrc")
@@ -29,7 +39,7 @@ describe("detectPnpm11Issues", () => {
     const dir = tmp()
     try {
       writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x", pnpm: { overrides: { a: "1" } } }))
-      const results = detectPnpm11Issues(dir).toArray()
+      const results = detectPnpm11Issues(dir, noReleaseAgeProbe).toArray()
       expect(results).toHaveLength(1)
       expect(results[0].severity).toBe("warning")
       expect(results[0].message).toContain("package.json 'pnpm' field")
@@ -43,7 +53,7 @@ describe("detectPnpm11Issues", () => {
     try {
       writeFileSync(join(dir, ".npmrc"), "public-hoist-pattern[]=*eslint*\n")
       writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x", pnpm: { overrides: { a: "1" } } }))
-      const results = detectPnpm11Issues(dir).toArray()
+      const results = detectPnpm11Issues(dir, noReleaseAgeProbe).toArray()
       expect(results).toHaveLength(2)
       expect(results.every((r) => r.severity === "warning")).toBe(true)
     } finally {
@@ -55,13 +65,115 @@ describe("detectPnpm11Issues", () => {
     const dir = tmp()
     try {
       writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
-      const results = detectPnpm11Issues(dir).toArray()
+      const results = detectPnpm11Issues(dir, noReleaseAgeProbe).toArray()
       expect(results).toHaveLength(1)
       expect(results[0].severity).toBe("info")
       expect(results[0].message).toBe("pnpm 11 ready")
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
+  })
+
+  it("warns with the exact pkg@version when the probe reports a release-age violation", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      const probe: PnpmReleaseAgeProbe = () => ({
+        stdout: "",
+        stderr:
+          "[ERR_PNPM_NO_MATURE_MATCHING_VERSION] 1 version does not meet the minimumReleaseAge constraint:\n" +
+          "  left-pad@1.3.0 was published at 2018-04-09T01:10:45.796Z, within the minimumReleaseAge cutoff (2026-06-05T00:00:00.000Z)\n",
+        status: 1,
+      })
+      const results = detectPnpm11Issues(dir, probe).toArray()
+      const warning = results.find((r) => r.message.includes("left-pad@1.3.0"))
+      expect(warning).toBeDefined()
+      expect(warning?.severity).toBe("warning")
+      expect(warning?.message).toContain("minimumReleaseAgeExclude")
+      expect(warning?.message).toContain("left-pad@1.3.0")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("does not emit a release-age warning when the probe reports no violation", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      const probe: PnpmReleaseAgeProbe = () => ({ stdout: "", stderr: "", status: 0 })
+      const results = detectPnpm11Issues(dir, probe).toArray()
+      expect(results.some((r) => r.message.includes("minimumReleaseAge"))).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("degrades quietly on an unrelated probe failure (no false warning, no crash)", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      const probe: PnpmReleaseAgeProbe = () => ({
+        stdout: "",
+        stderr: "[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/nope: Not Found",
+        status: 1,
+      })
+      const results = detectPnpm11Issues(dir, probe).toArray()
+      expect(results.some((r) => r.message.includes("minimumReleaseAge"))).toBe(false)
+      // Existing detection still works: with no .npmrc / pnpm field this stays "ready".
+      expect(results).toHaveLength(1)
+      expect(results[0].severity).toBe("info")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("parseReleaseAgeViolations", () => {
+  it("extracts a single pkg@version from real pnpm 11 stderr", () => {
+    const stderr =
+      "[ERR_PNPM_NO_MATURE_MATCHING_VERSION] 1 version does not meet the minimumReleaseAge constraint:\n" +
+      "  left-pad@1.3.0 was published at 2018-04-09T01:10:45.796Z, within the minimumReleaseAge cutoff (2026-06-05T00:00:00.000Z)\n"
+    expect(parseReleaseAgeViolations("", stderr)).toEqual(["left-pad@1.3.0"])
+  })
+
+  it("extracts multiple pkg@version entries preserving order and de-duplicating", () => {
+    const stderr =
+      "[ERR_PNPM_NO_MATURE_MATCHING_VERSION] 3 versions do not meet the minimumReleaseAge constraint:\n" +
+      "  is-number@6.0.0 was published at 2018-03-31T17:02:39.953Z, within the minimumReleaseAge cutoff (X)\n" +
+      "  is-odd@3.0.1 was published at 2018-05-31T20:04:53.306Z, within the minimumReleaseAge cutoff (X)\n" +
+      "  left-pad@1.3.0 was published at 2018-04-09T01:10:45.796Z, within the minimumReleaseAge cutoff (X)\n" +
+      "  is-odd@3.0.1 was published at 2018-05-31T20:04:53.306Z, within the minimumReleaseAge cutoff (X)\n"
+    expect(parseReleaseAgeViolations("", stderr)).toEqual(["is-number@6.0.0", "is-odd@3.0.1", "left-pad@1.3.0"])
+  })
+
+  it("handles scoped packages", () => {
+    const stderr =
+      "  @eslint/js@9.0.0 was published at 2026-06-05T00:00:00.000Z, within the minimumReleaseAge cutoff (X)\n"
+    expect(parseReleaseAgeViolations("", stderr)).toEqual(["@eslint/js@9.0.0"])
+  })
+
+  it("also recognizes the ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION marker", () => {
+    const stderr =
+      "[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] foo@2.1.0 was published within the minimumReleaseAge cutoff\n"
+    expect(parseReleaseAgeViolations("", stderr)).toEqual(["foo@2.1.0"])
+  })
+
+  it("returns no violations for unrelated error output", () => {
+    expect(
+      parseReleaseAgeViolations("", "[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/nope: Not Found"),
+    ).toEqual([])
+  })
+
+  it("returns no violations for empty output", () => {
+    expect(parseReleaseAgeViolations("", "")).toEqual([])
+  })
+})
+
+describe("buildReleaseAgeExcludeLine", () => {
+  it("renders a minimumReleaseAgeExclude suggestion naming the pkg@version", () => {
+    const line = buildReleaseAgeExcludeLine("left-pad@1.3.0")
+    expect(line).toContain("minimumReleaseAgeExclude")
+    expect(line).toContain("left-pad@1.3.0")
   })
 })
 

--- a/test/pnpm11.spec.ts
+++ b/test/pnpm11.spec.ts
@@ -10,6 +10,7 @@ import {
   detectPnpm11Issues,
   migratePnpm11,
   parseReleaseAgeViolations,
+  readAllowBuildsKeys,
 } from "../src/cli/pnpm11"
 
 function tmp(): string {
@@ -175,6 +176,152 @@ describe("buildReleaseAgeExcludeLine", () => {
     const line = buildReleaseAgeExcludeLine("left-pad@1.3.0")
     expect(line).toContain("minimumReleaseAgeExclude")
     expect(line).toContain("left-pad@1.3.0")
+  })
+})
+
+// ─── B2: allowBuilds / esbuild detection ────────────────────────────────────
+
+describe("readAllowBuildsKeys", () => {
+  it("returns empty set when allowBuilds block is absent", () => {
+    const yaml = "packages:\n  - '**'\n"
+    expect(readAllowBuildsKeys(yaml).size).toBe(0)
+  })
+
+  it("parses a single key", () => {
+    const yaml = "allowBuilds:\n  esbuild: false\n"
+    const keys = readAllowBuildsKeys(yaml)
+    expect(keys.has("esbuild")).toBe(true)
+    expect(keys.size).toBe(1)
+  })
+
+  it("parses multiple keys (true and false values)", () => {
+    const yaml = "allowBuilds:\n  esbuild: false\n  some-other: true\n"
+    const keys = readAllowBuildsKeys(yaml)
+    expect(keys.has("esbuild")).toBe(true)
+    expect(keys.has("some-other")).toBe(true)
+    expect(keys.size).toBe(2)
+  })
+
+  it("stops parsing allowBuilds block at the next top-level key", () => {
+    const yaml = "allowBuilds:\n  esbuild: false\noverrides:\n  foo: '1'\n"
+    const keys = readAllowBuildsKeys(yaml)
+    expect(keys.has("esbuild")).toBe(true)
+    expect(keys.has("overrides")).toBe(false)
+    expect(keys.size).toBe(1)
+  })
+
+  it("returns empty set for empty string", () => {
+    expect(readAllowBuildsKeys("").size).toBe(0)
+  })
+})
+
+// Minimal pnpm-lock.yaml v9 snippet that places esbuild under packages:
+const LOCKFILE_WITH_ESBUILD = `lockfileVersion: '9.0'
+
+packages:
+  esbuild@0.25.4:
+    resolution: {integrity: sha512-xxx}
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-yyy}
+
+snapshots:
+  esbuild@0.25.4:
+    dependencies: {}
+`
+
+const LOCKFILE_WITHOUT_ESBUILD = `lockfileVersion: '9.0'
+
+packages:
+  typescript@5.8.3:
+    resolution: {integrity: sha512-yyy}
+`
+
+describe("detectPnpm11Issues — B2 esbuild allowBuilds detection", () => {
+  it("warns and proposes allowBuilds.esbuild:false when esbuild in lockfile but no allowBuilds declared", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-lock.yaml"), LOCKFILE_WITH_ESBUILD)
+      writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '**'\n")
+      const results = detectPnpm11Issues(dir, noReleaseAgeProbe).toArray()
+      const warning = results.find((r) => r.message.includes("esbuild"))
+      expect(warning).toBeDefined()
+      expect(warning?.severity).toBe("warning")
+      expect(warning?.message).toContain("ERR_PNPM_IGNORED_BUILDS")
+      expect(warning?.message).toContain("allowBuilds:")
+      expect(warning?.message).toContain("esbuild: false")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("does NOT warn when esbuild is already declared under allowBuilds (false)", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-lock.yaml"), LOCKFILE_WITH_ESBUILD)
+      writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '**'\nallowBuilds:\n  esbuild: false\n")
+      const results = detectPnpm11Issues(dir, noReleaseAgeProbe).toArray()
+      expect(results.some((r) => r.message.includes("esbuild"))).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("does NOT warn when esbuild is declared under allowBuilds (true)", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-lock.yaml"), LOCKFILE_WITH_ESBUILD)
+      writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '**'\nallowBuilds:\n  esbuild: true\n")
+      const results = detectPnpm11Issues(dir, noReleaseAgeProbe).toArray()
+      expect(results.some((r) => r.message.includes("esbuild"))).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("does NOT warn when no lockfile is present", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      // no pnpm-lock.yaml
+      const results = detectPnpm11Issues(dir, noReleaseAgeProbe).toArray()
+      expect(results.some((r) => r.message.includes("esbuild"))).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("does NOT warn when lockfile exists but esbuild is not present in it", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-lock.yaml"), LOCKFILE_WITHOUT_ESBUILD)
+      const results = detectPnpm11Issues(dir, noReleaseAgeProbe).toArray()
+      expect(results.some((r) => r.message.includes("esbuild"))).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("does NOT warn when no pnpm-workspace.yaml exists but allowBuilds is also absent (no workspace = no strictDepBuilds context)", () => {
+    // When there's no workspace file at all, esbuild in the lockfile is still
+    // un-decided. We DO warn because strictDepBuilds defaults to true in pnpm 11
+    // even without a workspace file — the user needs to add allowBuilds somewhere.
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-lock.yaml"), LOCKFILE_WITH_ESBUILD)
+      // no pnpm-workspace.yaml at all
+      const results = detectPnpm11Issues(dir, noReleaseAgeProbe).toArray()
+      const warning = results.find((r) => r.message.includes("esbuild"))
+      expect(warning).toBeDefined()
+      expect(warning?.severity).toBe("warning")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/test/pnpm11.spec.ts
+++ b/test/pnpm11.spec.ts
@@ -152,9 +152,10 @@ describe("parseReleaseAgeViolations", () => {
     expect(parseReleaseAgeViolations("", stderr)).toEqual(["@eslint/js@9.0.0"])
   })
 
-  it("also recognizes the ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION marker", () => {
-    const stderr =
-      "[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] foo@2.1.0 was published within the minimumReleaseAge cutoff\n"
+  it("matches on the per-violation line, independent of the header error code", () => {
+    // Robustness: we key off the line wording ("... was published ... minimumReleaseAge"),
+    // not the header code, so a future pnpm code/format tweak still parses.
+    const stderr = "[ERR_PNPM_SOME_FUTURE_CODE] foo@2.1.0 was published within the minimumReleaseAge cutoff\n"
     expect(parseReleaseAgeViolations("", stderr)).toEqual(["foo@2.1.0"])
   })
 

--- a/test/pnpm11.spec.ts
+++ b/test/pnpm11.spec.ts
@@ -449,3 +449,211 @@ describe("migratePnpm11", () => {
     }
   })
 })
+
+// ─── B3: --fix writes minimumReleaseAgeExclude + allowBuilds entries ─────────
+
+// Count occurrences of a top-level key (anchored line start, ends with colon).
+function topLevelKeyCount(yaml: string, key: string): number {
+  return (yaml.match(new RegExp(`^${key}:`, "gm")) ?? []).length
+}
+
+function probeReporting(...tokens: string[]): PnpmReleaseAgeProbe {
+  return () => ({
+    stdout: "",
+    stderr: tokens
+      .map((t) => `  ${t} was published at 2026-06-05T00:00:00.000Z, within the minimumReleaseAge cutoff (X)`)
+      .join("\n"),
+    status: tokens.length > 0 ? 1 : 0,
+  })
+}
+
+describe("migratePnpm11 — B3 minimumReleaseAgeExclude", () => {
+  it("appends a new block with a PINNED entry for a non-first-party violation", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '**'\n")
+      const report = migratePnpm11(dir, probeReporting("@types/node@24.13.1"))
+      const ws = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
+      expect(ws).toContain("minimumReleaseAgeExclude:")
+      expect(ws).toContain(`  - "@types/node@24.13.1"`)
+      expect(report.actions.some((a) => a.kind === "migrated" && a.message.includes("minimumReleaseAgeExclude"))).toBe(
+        true,
+      )
+      expect(report.errors).toBe(0)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("uses a BARE entry for a first-party violation (functype-os)", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '**'\n")
+      migratePnpm11(dir, probeReporting("functype-os@1.2.3"))
+      const ws = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
+      expect(ws).toContain("minimumReleaseAgeExclude:")
+      expect(ws).toContain("  - functype-os")
+      expect(ws).not.toContain("functype-os@1.2.3")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("inserts into an EXISTING block, preserving entries and not duplicating the top-level key", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(
+        join(dir, "pnpm-workspace.yaml"),
+        `packages:\n  - '**'\nminimumReleaseAgeExclude:\n  - "already@1.0.0"\n  - functype\n`,
+      )
+      migratePnpm11(dir, probeReporting("@types/node@24.13.1"))
+      const ws = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
+      expect(topLevelKeyCount(ws, "minimumReleaseAgeExclude")).toBe(1)
+      expect(ws).toContain(`  - "already@1.0.0"`)
+      expect(ws).toContain("  - functype")
+      expect(ws).toContain(`  - "@types/node@24.13.1"`)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("does not add a pinned entry when its bare name is already excluded", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(
+        join(dir, "pnpm-workspace.yaml"),
+        `packages:\n  - '**'\nminimumReleaseAgeExclude:\n  - functype-os\n`,
+      )
+      // functype-os is first-party → maps to bare "functype-os", already present.
+      const report = migratePnpm11(dir, probeReporting("functype-os@9.9.9"))
+      const ws = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
+      expect(ws).not.toContain("functype-os@9.9.9")
+      // Nothing new to add for the release-age dimension.
+      expect(report.actions.some((a) => a.message.includes("minimumReleaseAgeExclude") && a.kind === "migrated")).toBe(
+        false,
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("adds no release-age entries when the probe reports nothing", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '**'\n")
+      const report = migratePnpm11(dir, noReleaseAgeProbe)
+      const ws = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
+      expect(ws).not.toContain("minimumReleaseAgeExclude")
+      expect(report.actions.length).toBe(0)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("migratePnpm11 — B3 allowBuilds", () => {
+  it("appends allowBuilds.esbuild:false when esbuild is in the lockfile and undecided", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-lock.yaml"), LOCKFILE_WITH_ESBUILD)
+      writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '**'\n")
+      const report = migratePnpm11(dir, noReleaseAgeProbe)
+      const ws = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
+      expect(ws).toContain("allowBuilds:")
+      expect(ws).toContain("  esbuild: false")
+      expect(report.actions.some((a) => a.kind === "migrated" && a.message.includes("allowBuilds"))).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("makes no allowBuilds change when esbuild is already decided", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-lock.yaml"), LOCKFILE_WITH_ESBUILD)
+      writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '**'\nallowBuilds:\n  esbuild: false\n")
+      const report = migratePnpm11(dir, noReleaseAgeProbe)
+      const ws = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
+      expect(topLevelKeyCount(ws, "allowBuilds")).toBe(1)
+      expect((ws.match(/esbuild: false/g) ?? []).length).toBe(1)
+      expect(report.actions.some((a) => a.message.includes("allowBuilds"))).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("inserts into an EXISTING allowBuilds block without duplicating the top-level key", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-lock.yaml"), LOCKFILE_WITH_ESBUILD)
+      writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '**'\nallowBuilds:\n  some-other: true\n")
+      migratePnpm11(dir, noReleaseAgeProbe)
+      const ws = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
+      expect(topLevelKeyCount(ws, "allowBuilds")).toBe(1)
+      expect(ws).toContain("  some-other: true")
+      expect(ws).toContain("  esbuild: false")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("adds no allowBuilds entries when there is no lockfile", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '**'\n")
+      migratePnpm11(dir, noReleaseAgeProbe)
+      const ws = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
+      expect(ws).not.toContain("allowBuilds")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("migratePnpm11 — B3 integration & idempotence (acceptance proxy)", () => {
+  // The real `pnpm install` clean-run verification is done manually in B4.
+  // Here the deterministic stand-in for "clean" is: each top-level key appears
+  // at most once, and a second migrate with the same probe is a no-op.
+  it("produces single top-level keys and is idempotent across all surfaces", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x", pnpm: { overrides: { foo: "1.0.0" } } }))
+      writeFileSync(join(dir, ".npmrc"), "public-hoist-pattern[]=*eslint*\n")
+      writeFileSync(join(dir, "pnpm-lock.yaml"), LOCKFILE_WITH_ESBUILD)
+      writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '**'\n")
+
+      const probe = probeReporting("@types/node@24.13.1", "functype@1.5.0")
+      const report1 = migratePnpm11(dir, probe)
+      const ws1 = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
+
+      // Each top-level key at most once.
+      for (const key of ["publicHoistPattern", "overrides", "minimumReleaseAgeExclude", "allowBuilds"]) {
+        expect(topLevelKeyCount(ws1, key)).toBe(1)
+      }
+      // Pinned vs bare per first-party rule.
+      expect(ws1).toContain(`  - "@types/node@24.13.1"`)
+      expect(ws1).toContain("  - functype")
+      expect(ws1).not.toContain("functype@1.5.0")
+      expect(ws1).toContain("  esbuild: false")
+      expect(report1.errors).toBe(0)
+
+      // Idempotence: a second run with the same probe is a no-op.
+      const report2 = migratePnpm11(dir, probe)
+      const ws2 = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
+      expect(ws2).toBe(ws1)
+      expect(report2.actions.length).toBe(0)
+      expect(report2.errors).toBe(0)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/pnpm11.spec.ts
+++ b/test/pnpm11.spec.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest"
 import type { PnpmReleaseAgeProbe } from "../src/cli/pnpm11"
 import {
   buildReleaseAgeExcludeLine,
+  defaultReleaseAgeProbe,
   detectPnpm11Issues,
   migratePnpm11,
   parseReleaseAgeViolations,
@@ -613,6 +614,59 @@ describe("migratePnpm11 — B3 allowBuilds", () => {
       migratePnpm11(dir, noReleaseAgeProbe)
       const ws = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
       expect(ws).not.toContain("allowBuilds")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("migratePnpm11 — block (d) reads the lockfile before the probe runs (Bug 2)", () => {
+  it("writes allowBuilds.esbuild:false even when the probe mutates the lockfile away", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-lock.yaml"), LOCKFILE_WITH_ESBUILD)
+      writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '**'\n")
+
+      // Simulate the real Bug 2: the probe clobbers the consumer lockfile (as a
+      // mutating `pnpm install --resolution-only` would) and reports no
+      // release-age violations. Block (d) must NOT depend on the post-probe
+      // lockfile — it must use the contents read before the probe ran.
+      const mutatingProbe: PnpmReleaseAgeProbe = () => {
+        writeFileSync(join(dir, "pnpm-lock.yaml"), LOCKFILE_WITHOUT_ESBUILD)
+        return { stdout: "", stderr: "", status: 0 }
+      }
+
+      const report = migratePnpm11(dir, mutatingProbe)
+      const ws = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
+      expect(ws).toContain("allowBuilds:")
+      expect(ws).toContain("  esbuild: false")
+      expect(report.actions.some((a) => a.kind === "migrated" && a.message.includes("allowBuilds"))).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("defaultReleaseAgeProbe — side-effect-free (Bug 1)", () => {
+  it("leaves an existing pnpm-lock.yaml byte-for-byte unchanged after probing", () => {
+    const dir = tmp()
+    try {
+      // Trivial manifest so pnpm (if present) has something to resolve, and a
+      // lockfile with sentinel bytes the real probe could otherwise rewrite.
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "probe-fixture", version: "0.0.0" }))
+      const lockPath = join(dir, "pnpm-lock.yaml")
+      const sentinel = "lockfileVersion: '9.0'\n\n# sentinel-do-not-rewrite\nsettings:\n  autoInstallPeers: true\n"
+      writeFileSync(lockPath, sentinel)
+      const before = readFileSync(lockPath)
+
+      // Real probe — shells out to pnpm. If pnpm is missing it returns status -1
+      // and never mutated anything; if present it may try to rewrite, and the
+      // snapshot/restore must put the bytes back. The invariant holds either way.
+      defaultReleaseAgeProbe(dir)
+
+      const after = readFileSync(lockPath)
+      expect(after.equals(before)).toBe(true)
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }


### PR DESCRIPTION
Makes ts-builds the single source of truth for the pnpm 11 migration story. Two surfaces were out of sync with the 3.0.0 reality; this fixes both and hardens the new detection.

## Phase A — agent-facing skill synced (docs)
- Corrected stale `.npmrc` "init creates" claims → `pnpm-workspace.yaml` (`publicHoistPattern`)
- Added a "pnpm 11 defaults" reference section to `SKILL.md` (on-by-default settings + config surface + `allowBuilds`)
- Added a step-by-step 2.x→3.0.0 / pnpm 10→11 runbook to `references/standardization.md` with cross-references

The skill ships via the git/plugin marketplace (not npm), so it refreshes once this lands on `main`.

## Phase B — `doctor` now guides the judgment calls (feature)
- **`minimumReleaseAge` detection**: pure parser behind an injectable, **side-effect-free** pnpm probe (`pnpm install --resolution-only` with lockfile snapshot/restore; degrades quietly if pnpm is absent)
- **`allowBuilds` gap detection**: static lockfile-vs-`allowBuilds` comparison for a curated known-safe set (`esbuild`); no mutating install
- **`--fix`**: writes/merges `minimumReleaseAgeExclude` (pinned for third-party, bare for first-party `ts-builds`/`functype`/`functype-*`) + `allowBuilds` into `pnpm-workspace.yaml` — preserves existing content, never duplicates a top-level key, idempotent

Verified end-to-end with the real CLI: `--fix` adds `allowBuilds: esbuild: false`, preserves the lockfile, and a follow-up `doctor` reports "pnpm 11 ready".

## Corrections made along the way
1. **Fabricated error code fixed.** The plan's `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` does not exist in pnpm; verified the real code is `ERR_PNPM_NO_MATURE_MATCHING_VERSION` and corrected it across the skill, code comments, and plan.
2. **Probe mutation flaw fixed.** `pnpm install --resolution-only` rewrites a stale lockfile — plain `doctor` would have silently mutated a consumer's `pnpm-lock.yaml`, and `--fix` missed esbuild because the probe clobbered the lockfile before the allowBuilds read. Fixed via snapshot/restore + reading the lockfile before the probe.
3. **Pre-existing red `main` fixed.** `pnpm validate` was already failing (functype 1.2.x dropped `List.nonEmpty`; a `runFn` narrowing gap; an import-sort error) — unrelated to this work, fixed in a separate commit so validate is green.

## Validation
prettier ✓ · eslint ✓ · tsc ✓ · **139 tests** ✓ · build ✓

Version bumped to **3.0.1**. After merge, push the `v3.0.1` tag to trigger the npm publish (workflow uses Node 24 + OIDC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)