### PR TITLE
fix(build): non-destructive clean to avoid emptying dist mid-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-builds",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Shared TypeScript configuration files for library templates. Provides standardized ESLint, Prettier, Vitest, TypeScript, and build configs.",
   "keywords": [
     "typescript",

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -1,4 +1,4 @@
-import { rm } from "node:fs/promises"
+import { readdir, rm, stat } from "node:fs/promises"
 import { join } from "node:path"
 
 import { loadConfig, targetDir } from "../config"
@@ -71,16 +71,72 @@ export async function runTest(mode: "run" | "watch" | "coverage" | "ui" = "run")
 }
 
 /**
+ * Recursively map every file under `dir` to its mtime (ms). Returns an empty
+ * map when `dir` doesn't exist. Best-effort: unreadable entries are skipped.
+ */
+export async function snapshotMtimes(dir: string): Promise<Map<string, number>> {
+  const out = new Map<string, number>()
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries) {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      for (const [p, m] of await snapshotMtimes(path)) out.set(p, m)
+    } else {
+      const mtime = await stat(path)
+        .then((s) => s.mtimeMs)
+        .catch(() => undefined)
+      if (mtime !== undefined) out.set(path, mtime)
+    }
+  }
+  return out
+}
+
+/**
+ * Non-destructive clean: remove only the build outputs left *untouched* by the
+ * latest build — orphans from a previous build whose source entry no longer
+ * exists (including old content-hashed chunk files).
+ *
+ * A file is an orphan iff it was present in `before` AND its mtime is unchanged
+ * afterwards: tsdown rewrites every current output, so anything it produced has
+ * a newer mtime, and anything still bearing its pre-build mtime is stale. This
+ * yields the same orphan-free result as `rm -rf dist` without ever unlinking a
+ * file mid-build — see {@link runBuild}.
+ *
+ * Best-effort: a failed unlink leaves a (harmless) orphan rather than failing
+ * the build.
+ */
+export async function pruneOrphans(distDir: string, before: Map<string, number>): Promise<void> {
+  for (const [path, mtimeBefore] of before) {
+    const mtimeNow = await stat(path)
+      .then((s) => s.mtimeMs)
+      .catch(() => undefined)
+    if (mtimeNow === mtimeBefore) {
+      await rm(path, { force: true }).catch(() => undefined)
+    }
+  }
+}
+
+/**
  * Production build (or watch build, when `watch === true`).
  *
- * Two design choices worth knowing about before editing:
+ * Three design choices worth knowing about before editing:
  *
- * 1. **Clean is done via Node's `fs.rm`, not a shelled-out `rimraf`.**
+ * 1. **Non-destructive clean (tsdown path).** Rather than `rm -rf dist` before
+ *    building — which leaves a window where `dist/` is empty and a concurrent
+ *    reader (e.g. a sibling package's tests executing this package's built
+ *    output under a monorepo task runner) hits "Cannot find module" — we build
+ *    over the existing `dist` with `--no-clean` (overriding `clean: true` in
+ *    the shared tsdown base config, so outputs are overwritten in place and
+ *    `dist` is never momentarily empty), then {@link pruneOrphans} removes
+ *    files the build didn't touch. Same orphan-free result, no missing-file
+ *    window. (Vite mode keeps the clean-before-build path for now.)
+ *
+ * 2. **Clean is done via Node's `fs.rm`, not a shelled-out `rimraf`.**
  *    See {@link cleanDir} — it handles the Windows transient-error cases
  *    that `rimraf` previously papered over, without dragging `rimraf` into
  *    consumers' install graphs.
  *
- * 2. **`NODE_ENV=production` is passed through `spawn`'s `env` option, not
+ * 3. **`NODE_ENV=production` is passed through `spawn`'s `env` option, not
  *    by assigning `process.env.NODE_ENV` in the parent process.** Mutating
  *    `process.env` would leak production semantics into any later code in
  *    the same process — fine for the one-shot CLI binary, dangerous when
@@ -100,9 +156,13 @@ export async function runBuild(watch = false): Promise<number> {
   }
 
   if (watch) return runCommand("tsdown", ["--watch"])
-  const cleanCode = await cleanDist()
-  if (cleanCode !== 0) return cleanCode
-  return runCommand("tsdown", [], { env: { NODE_ENV: "production" } })
+
+  const distDir = join(targetDir, "dist")
+  const before = await snapshotMtimes(distDir)
+  const buildCode = await runCommand("tsdown", ["--no-clean"], { env: { NODE_ENV: "production" } })
+  if (buildCode !== 0) return buildCode
+  await pruneOrphans(distDir, before)
+  return 0
 }
 
 export async function runDev(): Promise<number> {

--- a/test/commands/build.spec.ts
+++ b/test/commands/build.spec.ts
@@ -4,11 +4,13 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 
-import { cleanDir } from "../../src/cli/commands/build"
+import { cleanDir, pruneOrphans, snapshotMtimes } from "../../src/cli/commands/build"
 
 function makeTempDir(): string {
   return mkdtempSync(join(tmpdir(), "ts-builds-clean-"))
 }
+
+const tick = (ms = 12): Promise<void> => new Promise((r) => setTimeout(r, ms))
 
 describe("cleanDir", () => {
   it("removes a populated directory and returns 0", async () => {
@@ -50,6 +52,75 @@ describe("cleanDir", () => {
       const code = await cleanDir(target)
       expect(code).toBe(0)
       expect(existsSync(target)).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("snapshotMtimes", () => {
+  it("returns an empty map when the directory does not exist", async () => {
+    const dir = makeTempDir()
+    try {
+      const snap = await snapshotMtimes(join(dir, "never-existed"))
+      expect(snap.size).toBe(0)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("records every file recursively", async () => {
+    const dir = makeTempDir()
+    try {
+      const dist = join(dir, "dist")
+      await mkdir(join(dist, "rules"), { recursive: true })
+      writeFileSync(join(dist, "index.js"), "a")
+      writeFileSync(join(dist, "rules", "x.js"), "b")
+      const snap = await snapshotMtimes(dist)
+      expect(snap.size).toBe(2)
+      expect(snap.has(join(dist, "index.js"))).toBe(true)
+      expect(snap.has(join(dist, "rules", "x.js"))).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("pruneOrphans", () => {
+  it("removes files untouched since the snapshot, keeps rewritten and new files", async () => {
+    const dir = makeTempDir()
+    try {
+      const dist = join(dir, "dist")
+      await mkdir(dist, { recursive: true })
+      writeFileSync(join(dist, "keep.js"), "old")
+      writeFileSync(join(dist, "orphan.js"), "stale")
+
+      const before = await snapshotMtimes(dist)
+
+      // Simulate a --no-clean build: rewrite keep.js (newer mtime), add new.js,
+      // leave orphan.js untouched (its source entry no longer exists).
+      await tick()
+      writeFileSync(join(dist, "keep.js"), "new")
+      writeFileSync(join(dist, "new.js"), "fresh")
+
+      await pruneOrphans(dist, before)
+
+      expect(existsSync(join(dist, "keep.js"))).toBe(true)
+      expect(existsSync(join(dist, "new.js"))).toBe(true)
+      expect(existsSync(join(dist, "orphan.js"))).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("no-ops on an empty snapshot (fresh dist)", async () => {
+    const dir = makeTempDir()
+    try {
+      const dist = join(dir, "dist")
+      await mkdir(dist, { recursive: true })
+      writeFileSync(join(dist, "index.js"), "a")
+      await pruneOrphans(dist, new Map())
+      expect(existsSync(join(dist, "index.js"))).toBe(true)
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Problem

`runBuild` does `rm -rf dist` *before* invoking tsdown (and tsdown's own `clean: true` cleans again). That leaves a window where `dist/` is empty. A concurrent reader — e.g. a sibling package's tests **executing** this package's built output under a monorepo task runner (turbo / nx / `pnpm -r`) — intermittently hits:

```
Error: Cannot find module '.../dist/rules/prefer-either.js' imported from .../dist/rules/index.js
```

(Surfaced downstream in the functype monorepo: `functype-eval`'s tests run `eslint-plugin-functype` via the ESLint Node API, and `eslint-plugin-functype#validate`'s rebuild raced those tests under `turbo run validate`.)

## Fix

Make the tsdown build **non-destructive**:

1. Snapshot `dist` file mtimes.
2. Build with `tsdown --no-clean` — overwrites every current output **in place**, so `dist` is never momentarily empty (`--no-clean` overrides `clean: true` in the shared tsdown base config).
3. Prune orphans: files present before the build whose mtime is **unchanged** afterwards. tsdown rewrites every current output (newer mtime), so a stale mtime means a removed entry — including old content-hashed chunk files.

Same orphan-free result as `rm -rf dist`, with no missing-file window for concurrent readers.

## Why not 4.0 / why this doesn't weaken ts-builds

- **Backward compatible.** `build` and `validate` keep identical observable behavior — they still build and still yield an orphan-free `dist`. `validate` still asserts the build succeeds. No contract change → minor bump.
- It *strengthens* ts-builds: builds are now safe to run concurrently with readers, which is the world the #72 "let Turbo orchestrate" direction is steering toward.
- Vite mode is unchanged (keeps clean-before-build); the race is the tsdown library-build path.

**Honest residual:** this removes the observed/dominant failure (file deleted). A far narrower window remains — importing a `.js` during the millisecond tsdown truncates-and-rewrites that one file. Eliminating that too is atomic build-to-temp-then-rename (sourcemap-path caveats); deferred unless it ever bites.

## Verification

- `pnpm validate` green (143 tests, incl. new `snapshotMtimes`/`pruneOrphans` unit tests); exercises the new build path on ts-builds' own dist.
- Empirical: dropped an orphan into `dist`, ran `pnpm build` → orphan pruned, real outputs (`dist/cli.js`) intact, dist never emptied.

→ **3.1.0** (new exported helpers + behavior improvement, backward compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)