### PR TITLE
feat(pnpm11): hoist globals + collapse first-party release-age excludes to *functype* glob

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -4,7 +4,10 @@ import { join } from "node:path"
 import type { TsBuildsConfig } from "../config"
 import { targetDir } from "../config"
 
-const hoistPatterns = ["*eslint*", "*prettier*", "*vitest*", "typescript"]
+// `globals` is imported by the standard flat eslint.config.js but isn't matched
+// by `*eslint*`, so without hoisting it the config fails to resolve at the repo
+// root under pnpm's strict linking (ERR_MODULE_NOT_FOUND on a clean install).
+const hoistPatterns = ["*eslint*", "*prettier*", "*vitest*", "typescript", "globals"]
 
 function renderHoistBlock(): string {
   return "publicHoistPattern:\n" + hoistPatterns.map((p) => `  - "${p}"`).join("\n") + "\n"

--- a/src/cli/pnpm11.ts
+++ b/src/cli/pnpm11.ts
@@ -46,7 +46,7 @@ export function parseReleaseAgeViolations(stdout: string, stderr: string): strin
 
 /** Pure helper: the suggested pnpm-workspace.yaml exclude line for a flagged token. */
 export function buildReleaseAgeExcludeLine(pkgVersion: string): string {
-  return `minimumReleaseAgeExclude:\n  - "${pkgVersion}"`
+  return `minimumReleaseAgeExclude:\n${renderExcludeEntry(releaseAgeExcludeEntry(pkgVersion))}`
 }
 
 /**
@@ -295,13 +295,18 @@ function renderPeerDependencyRules(rules: NonNullable<PnpmField["peerDependencyR
 }
 
 /**
- * Packages we own and publish frequently; a release-age violation on these is
+ * First-party packages we publish ourselves — a release-age violation on these is
  * almost always "I just published it" rather than a supply-chain concern, so we
- * exclude by BARE name (all versions). Everything else is pinned to the exact
- * flagged version. Match by NAME only — `ts-builds`, `functype`, `functype-*`.
+ * exclude them at ALL versions instead of pinning (pins re-trip on every release).
+ *
+ * The functype family is open-ended (functype, functype-os, eslint-config-functype,
+ * eslint-plugin-functype, and future functype-*), so it collapses to a single
+ * `*functype*` name glob. `ts-builds` is a lone package excluded by bare name.
  */
-function isFirstParty(name: string): boolean {
-  return name === "ts-builds" || name === "functype" || name.startsWith("functype-")
+const FIRST_PARTY_FUNCTYPE_GLOB = "*functype*"
+
+function isFirstPartyFunctype(name: string): boolean {
+  return name.includes("functype")
 }
 
 /** Strip the trailing `@version` from a `pkg@version` token, scope-aware. */
@@ -311,14 +316,26 @@ function packageNameOf(token: string): string {
   return at > 0 ? token.slice(0, at) : token
 }
 
-/** The target exclude entry for a flagged token: bare name (first-party) or pinned token. */
-function releaseAgeExcludeEntry(token: string): string {
-  return isFirstParty(packageNameOf(token)) ? packageNameOf(token) : token
+/**
+ * Canonical exclude entry for a flagged `pkg@version` token — or for an existing
+ * entry being re-checked. First-party functype family → the `*functype*` glob,
+ * `ts-builds` → bare `ts-builds`, an entry that is already a glob/pattern is left
+ * untouched, and everything else (third-party) stays pinned to its exact version.
+ */
+function releaseAgeExcludeEntry(entry: string): string {
+  if (entry.includes("*")) return entry
+  const name = packageNameOf(entry)
+  if (isFirstPartyFunctype(name)) return FIRST_PARTY_FUNCTYPE_GLOB
+  if (name === "ts-builds") return "ts-builds"
+  return entry
 }
 
-/** Render a list entry, quoting pinned `pkg@version` forms, leaving bare names unquoted. */
+/**
+ * Render a list entry. Quote pinned (`@`), scoped, or glob (`*`) forms — a bare
+ * `*functype*` would otherwise be parsed as a YAML alias. Plain names stay unquoted.
+ */
 function renderExcludeEntry(entry: string): string {
-  return entry.includes("@") ? `  - "${entry}"` : `  - ${entry}`
+  return /[@*]/.test(entry) ? `  - "${entry}"` : `  - ${entry}`
 }
 
 /**
@@ -541,16 +558,18 @@ export function migratePnpm11(
   const { stdout, stderr } = releaseAgeProbe(dir)
   const violations = parseReleaseAgeViolations(stdout, stderr)
   if (violations.length > 0) {
-    const existing = readReleaseAgeExcludeEntries(ws)
+    // Canonicalize existing entries so any first-party form already present —
+    // a `functype@x` pin pnpm auto-added, a bare `functype-os`, or the `*functype*`
+    // glob itself — counts as covering a fresh functype-family violation, and we
+    // never pile on a redundant glob. Additive only: existing entries are read,
+    // never rewritten.
+    const covered = new Set<string>()
+    for (const e of readReleaseAgeExcludeEntries(ws)) covered.add(releaseAgeExcludeEntry(e))
     const newEntries: string[] = []
-    const seen = new Set<string>()
     for (const token of violations) {
       const entry = releaseAgeExcludeEntry(token)
-      // A bare first-party name already present suppresses a pinned form too,
-      // because readReleaseAgeExcludeEntries stores the normalized entry and
-      // releaseAgeExcludeEntry maps first-party tokens to that same bare name.
-      if (existing.has(entry) || seen.has(entry)) continue
-      seen.add(entry)
+      if (covered.has(entry)) continue
+      covered.add(entry)
       newEntries.push(entry)
     }
     if (newEntries.length > 0) {

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -83,6 +83,7 @@ describe("init pnpm-workspace.yaml generation", () => {
       expect(ws).toContain(`  - "*prettier*"`)
       expect(ws).toContain(`  - "*vitest*"`)
       expect(ws).toContain(`  - "typescript"`)
+      expect(ws).toContain(`  - "globals"`)
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/test/pnpm11.spec.ts
+++ b/test/pnpm11.spec.ts
@@ -487,7 +487,7 @@ describe("migratePnpm11 — B3 minimumReleaseAgeExclude", () => {
     }
   })
 
-  it("uses a BARE entry for a first-party violation (functype-os)", () => {
+  it("uses the *functype* glob for a first-party functype-family violation", () => {
     const dir = tmp()
     try {
       writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
@@ -495,8 +495,34 @@ describe("migratePnpm11 — B3 minimumReleaseAgeExclude", () => {
       migratePnpm11(dir, probeReporting("functype-os@1.2.3"))
       const ws = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
       expect(ws).toContain("minimumReleaseAgeExclude:")
-      expect(ws).toContain("  - functype-os")
+      expect(ws).toContain(`  - "*functype*"`)
       expect(ws).not.toContain("functype-os@1.2.3")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("collapses the whole functype family (incl. eslint-config/plugin-functype) to one *functype* glob and uses bare ts-builds", () => {
+    const dir = tmp()
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }))
+      writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '**'\n")
+      migratePnpm11(
+        dir,
+        probeReporting(
+          "functype@1.4.1",
+          "functype-os@1.4.1",
+          "eslint-config-functype@2.104.1",
+          "eslint-plugin-functype@2.104.1",
+          "ts-builds@3.1.1",
+        ),
+      )
+      const ws = readFileSync(join(dir, "pnpm-workspace.yaml"), "utf-8")
+      // All four functype-family packages collapse to a single glob entry.
+      expect(ws.match(/- "\*functype\*"/g)?.length).toBe(1)
+      expect(ws).toContain("  - ts-builds")
+      // None of the first-party packages are pinned to a version.
+      expect(ws).not.toMatch(/functype@|functype-os@|eslint-(config|plugin)-functype@|ts-builds@/)
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
@@ -693,9 +719,9 @@ describe("migratePnpm11 — B3 integration & idempotence (acceptance proxy)", ()
       for (const key of ["publicHoistPattern", "overrides", "minimumReleaseAgeExclude", "allowBuilds"]) {
         expect(topLevelKeyCount(ws1, key)).toBe(1)
       }
-      // Pinned vs bare per first-party rule.
+      // Pinned (third-party) vs *functype* glob (first-party) per the exclude rule.
       expect(ws1).toContain(`  - "@types/node@24.13.1"`)
-      expect(ws1).toContain("  - functype")
+      expect(ws1).toContain(`  - "*functype*"`)
       expect(ws1).not.toContain("functype@1.5.0")
       expect(ws1).toContain("  esbuild: false")
       expect(report1.errors).toBe(0)


### PR DESCRIPTION
## Summary

Two `pnpm-workspace.yaml` generation gaps surfaced while migrating a consumer (`microsoft-todo-mcp-server`) to ts-builds 3.x. Both are "generate-only" fixes — existing entries are read, never rewritten.

### 1. `init` omits `globals` from the hoist patterns
`ts-builds init` seeds `publicHoistPattern` with `*eslint*`/`*prettier*`/`*vitest*`/`typescript`, but the standard flat `eslint.config.js` also imports **`globals`**, which none of those patterns match. Under pnpm's strict linking it isn't resolvable at the repo root, so a clean `pnpm install --frozen-lockfile` fails ESLint with `ERR_MODULE_NOT_FOUND: Cannot find package 'globals'` (passes locally only due to looser dev linking). Added `globals` to the seeded patterns.

### 2. First-party release-age rule misses `eslint-config/plugin-functype`
`releaseAgeExcludeEntry` emits a bare (all-versions) entry for first-party packages and a per-version pin for third-party. But `isFirstParty` only matched `ts-builds` / `functype` / `functype-*`, so **`eslint-config-functype` and `eslint-plugin-functype`** were treated as third-party and pinned — re-tripping pnpm 11's `minimumReleaseAge` cooldown on every release.

Now the whole functype family (any name containing `functype`) collapses to a single **`*functype*`** glob, with `ts-builds` kept as a bare name — matching this repo's own `pnpm-workspace.yaml`. Supporting changes:
- `renderExcludeEntry` quotes glob/`@`/scoped forms (a bare `*functype*` would otherwise parse as a YAML alias).
- Dedup is glob-aware: an existing pin, bare name, or glob for a first-party package covers a fresh functype-family violation, so no redundant glob is appended.
- Still **additive** — existing entries are never rewritten (per the chosen scope; pnpm's own auto-added per-version pins are not collapsed).

## Tests
- Updated: first-party violation now expects `*functype*` (was bare `functype-os`); integration test expects the glob.
- Added: full functype family incl. `eslint-config/plugin-functype` collapses to one `*functype*` + bare `ts-builds`, none pinned; `init` emits `globals`.
- `pnpm validate` green — 144 tests pass. Verified a real `ts-builds init` emits `globals` and the dist CLI works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)