### PR TITLE
docs: fix dead template link in standardization guide

### DIFF
--- a/STANDARDIZATION_GUIDE.md
+++ b/STANDARDIZATION_GUIDE.md
@@ -1,6 +1,6 @@
 # TypeScript Project Script Standardization Guide
 
-This guide helps you standardize npm/pnpm scripts across TypeScript projects using the established pattern from [typescript-library-template](https://github.com/jordanburke/typescript-library-template).
+This guide helps you standardize npm/pnpm scripts across TypeScript projects using the established pattern from [ts-builds-template](https://github.com/jordanburke/ts-builds-template).
 
 ## Quick Copy-Paste Prompt for Claude Code
 


### PR DESCRIPTION
`STANDARDIZATION_GUIDE.md` still linked `typescript-library-template`, which was renamed to `ts-builds-template` (the old name now only redirects). Point at the current name.

Part of consolidating the standards docs: **ts-builds is the single source of truth** for this guide; the `ts-builds-template` repo's copy becomes a pointer here (separate PR on that repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)